### PR TITLE
Fix an issue where IE throws a syntax error

### DIFF
--- a/plugins/historia-compat-plugin/gatsby-node.js
+++ b/plugins/historia-compat-plugin/gatsby-node.js
@@ -11,7 +11,10 @@ exports.onCreateWebpackConfig = ({
       rules: [
         {
           test: /\.js$/,
-          include: path.resolve('node_modules/@weknow/gatsby-remark-twitter'),
+          include: [
+            path.resolve('node_modules/@weknow/gatsby-remark-twitter'),
+            path.resolve('node_modules/react-schemaorg'),
+          ],
           use: [
             loaders.js(),
           ],


### PR DESCRIPTION
react-schemaorg needs transpilation for IE.