### PR TITLE
Fix wrapper to fulfill the browser window

### DIFF
--- a/src/styles/styles.scss
+++ b/src/styles/styles.scss
@@ -13,7 +13,12 @@ html,
 body {
   background: #efefef;
   word-wrap: break-word;
-  height: 100%;
+  &,
+  > div,
+  > div > div,
+  > div > div > div {
+    height: 100%;
+  }
 }
 h1,
 h2,


### PR DESCRIPTION
Each of the wrapper elements need to be `height: 100%;` so that the footer sticks to the bottom of the browser area. This affects the following elements:

- body > div#___gatsby
- body > div#___gatsby > div
- body > div#___gatsby > div > div.ais-InstantSearch__root

No idea how to make them generally applied though 😕 