### PR TITLE
Fix Sidebar to `position: static;` in IE

### DIFF
--- a/src/components/Sidebar/index.tsx
+++ b/src/components/Sidebar/index.tsx
@@ -61,6 +61,7 @@ const SidebarContainer = styled(Bootstrap.Col)`
   padding-right: 0;
   width: 30%;
   top: 15px;
+  position: static;
   position: sticky;
   ${media.lessThan('tablet')`
     width: auto;


### PR DESCRIPTION
Gets rid of the sidebar element to have `position: relative;`

Before:
<img width="420" alt="" src="https://user-images.githubusercontent.com/6535425/54110754-8bb6c300-4425-11e9-994a-b833857af831.png">

After:
<img width="420" alt="" src="https://user-images.githubusercontent.com/6535425/54110764-91140d80-4425-11e9-84f3-cafc725d04be.png">
