### PR TITLE
Fix compat plugin not to transpile react* packages

### DIFF
--- a/plugins/historia-compat-plugin/gatsby-node.js
+++ b/plugins/historia-compat-plugin/gatsby-node.js
@@ -12,9 +12,9 @@ exports.onCreateWebpackConfig = ({
         {
           test: /\.js$/,
           include: [
-            path.resolve('node_modules/@weknow/gatsby-remark-twitter'),
-            path.resolve('node_modules/react'),
-            path.resolve('node_modules/react-schemaorg'),
+            path.join(path.resolve('node_modules/@weknow/gatsby-remark-twitter'), '/'),
+            path.join(path.resolve('node_modules/react'), '/'),
+            path.join(path.resolve('node_modules/react-schemaorg'), '/'),
           ],
           use: [
             loaders.js(),


### PR DESCRIPTION
Older implementation transpiled packages whose name start with react,
therefore some of the related packages like `react-dom` are
unintentionally included.