### PR TITLE
Remove GooglePlusShareButton and add PocketShareButton

### DIFF
--- a/src/components/Sidebar/buttons.tsx
+++ b/src/components/Sidebar/buttons.tsx
@@ -15,6 +15,10 @@ interface TwitterShareButtonProps extends ShareButtonProps {
   title: string | null
 }
 
+interface PocketShareButtonProps extends ShareButtonProps {
+  title: string | null
+}
+
 interface ShareLinkProps extends GatsbyLinkProps<{}> {
   color: string
   hover: string
@@ -103,16 +107,17 @@ export const FacebookShareButton = injectIntl<ShareButtonProps>(function Faceboo
   )
 })
 
-export const GooglePlusShareButton = injectIntl<ShareButtonProps>(function GooglePlusShareButton({
+export const PocketShareButton = injectIntl<PocketShareButtonProps>(function PocketShareButtonProps({
   url,
+  title,
   intl: {
     formatMessage,
   },
 }) {
-  const to = `https://plus.google.com/share?url=${encodeURIComponent(url)}`
+  const to = `https://getpocket.com/edit?title=${encodeURIComponent(title || '')}&url=${encodeURIComponent(url)}`
   return (
-    <ShareButton to={to} color="#dd4b39" hover="#c93725" title={formatMessage(messages.share_on, { service: formatMessage(messages.google_plus) })}>
-      <ShareButtonIcon name="google-plus" />
+    <ShareButton to={to} color="#ff2651" hover="#eb126e" title={formatMessage(messages.share_on, { service: formatMessage(messages.pocket) })}>
+      <ShareButtonIcon name="get-pocket" />
     </ShareButton>
   )
 })

--- a/src/components/Sidebar/index.tsx
+++ b/src/components/Sidebar/index.tsx
@@ -10,7 +10,7 @@ import messages from './messages'
 import {
   TwitterShareButton,
   FacebookShareButton,
-  GooglePlusShareButton,
+  PocketShareButton,
   HatenaShareButton,
   TumblrShareButton,
 } from './buttons'
@@ -213,7 +213,7 @@ const Sidebar = injectIntl<{}>(withMetadata(function Sidebar({
                 <>
                   <TwitterShareButton title={title} url={url} />
                   <FacebookShareButton url={url} />
-                  <GooglePlusShareButton url={url} />
+                  <PocketShareButton title={title} url={url} />
                   <HatenaShareButton url={url} />
                   <TumblrShareButton url={url} />
                 </>

--- a/src/components/Sidebar/messages.ts
+++ b/src/components/Sidebar/messages.ts
@@ -6,7 +6,7 @@ export default defineMessages({
   share_on: '{service} で共有',
   twitter: 'Twitter',
   facebook: 'Facebook',
-  google_plus: 'Google+',
+  pocket: 'Pocket',
   hatena: 'はてなブックマーク',
   tumblr: 'Tumblr',
   latest_articles: '最近の投稿',

--- a/translations/ja.yml
+++ b/translations/ja.yml
@@ -42,11 +42,11 @@ components:
     links: リンク
     share: 共有
     hatena: はてなブックマーク
+    pocket: Pocket
     tumblr: Tumblr
     twitter: Twitter
     facebook: Facebook
     share_on: '{service} で共有'
-    google_plus: Google+
     latest_articles: 最近の投稿
   Metadata:
     title: ちとくのホームページ


### PR DESCRIPTION
Google+ is going to shut down in April 2, 2019
https://support.google.com/plus/answer/9195133

Before:
<img width="322" alt="" src="https://user-images.githubusercontent.com/6535425/55221851-d02bc680-524d-11e9-818a-096d17d9ccdc.png">

After:
<img width="322" alt="" src="https://user-images.githubusercontent.com/6535425/55221858-d621a780-524d-11e9-98c6-52e2711379b6.png">
