### PR TITLE
Refactor path creation

### DIFF
--- a/plugins/historia-taxonomy-plugin/createArticles.js
+++ b/plugins/historia-taxonomy-plugin/createArticles.js
@@ -1,4 +1,5 @@
 const path = require('path')
+const { getPath } = require('./utils')
 
 const createArticles = async ({
   graphql,
@@ -27,7 +28,7 @@ const createArticles = async ({
       }
     }
     fragment FileNode on File {
-      directory: relativeDirectory
+      relativeDirectory
       name
     }
     fragment File on Node {
@@ -44,12 +45,7 @@ const createArticles = async ({
         file,
       } = article
 
-      const directory = file.directory.replace(/^posts(\/|$)/, '')
-      if (!directory) {
-        continue
-      }
-
-      const fullPath = '/' + path.join(directory, file.name)
+      const fullPath = getPath(file, 'index')
       const prev = articles[index + 1]
       const next = articles[index - 1]
 

--- a/plugins/historia-taxonomy-plugin/createQuery.js
+++ b/plugins/historia-taxonomy-plugin/createQuery.js
@@ -1,14 +1,6 @@
 const path = require('path')
 const removeMd = require('remove-markdown')
-
-const getPath = file => {
-  const directory = file.directory.replace(/^posts(\/|$)/, '/')
-  if (!directory) {
-    return
-  }
-
-  return path.join(directory, file.name === 'index' ? '/' : file.name)
-}
+const { getPath } = require('./utils')
 
 module.exports = () => ({
   query: `
@@ -52,7 +44,7 @@ module.exports = () => ({
       path
     }
     fragment FileNode on File {
-      directory: relativeDirectory
+      relativeDirectory
       name
     }
     fragment File on Node {

--- a/plugins/historia-taxonomy-plugin/createTaxonomies.js
+++ b/plugins/historia-taxonomy-plugin/createTaxonomies.js
@@ -92,7 +92,7 @@ const createTaxonomies = async ({
 
     for (const [ num, page ] of pages.entries()) {
       taxonomies.push({
-        path: path.join('tag', tag.slug, num ? String(num + 1) : 'index'),
+        path: '/' + path.join('tag', tag.slug, num ? String(num + 1) : 'index'),
         component: path.resolve('src/templates/taxonomy.tsx'),
         context: {
           category: null,

--- a/plugins/historia-taxonomy-plugin/gatsby-node.js
+++ b/plugins/historia-taxonomy-plugin/gatsby-node.js
@@ -1,5 +1,6 @@
 const createTaxonomies = require('./createTaxonomies')
 const createArticles = require('./createArticles')
+const { getPath } = require('./utils')
 
 exports.createPages = async (
   {
@@ -23,7 +24,7 @@ exports.createPages = async (
       continue
     }
     createPage(page)
-    paths.add(page)
+    paths.add(page.path)
   }
 }
 
@@ -79,6 +80,12 @@ exports.createResolvers = ({
         resolve(source) {
           // TODO: read excerpt_separator setting
           return source.rawMarkdownBody.includes('\n<!-- more -->\n')
+        },
+      },
+      path: {
+        type: 'String',
+        resolve(source, args, context) {
+          return getPath(context.nodeModel.getNodeById({ id: source.parent }))
         },
       },
     },

--- a/plugins/historia-taxonomy-plugin/utils.js
+++ b/plugins/historia-taxonomy-plugin/utils.js
@@ -1,0 +1,14 @@
+const path = require('path')
+
+const getDirectory = file => {
+  return file.relativeDirectory.replace(/^posts(\/|$)/, '/')
+}
+
+exports.getPath = (file, index = '/') => {
+  const directory = getDirectory(file)
+  if (!directory) {
+    return
+  }
+
+  return path.join(directory, file.name === 'index' ? index : file.name)
+}

--- a/src/components/Article/index.tsx
+++ b/src/components/Article/index.tsx
@@ -15,16 +15,8 @@ import ArticleBody, { ArticleComponentCollection } from 'components/ArticleBody'
 import ArticleContainer from 'components/ArticleContainer'
 import ArticleHeader from 'components/ArticleHeader'
 
-export const getPathFromArticleFile = (file: ArticleFile): string => (
-  `/${file.directory.replace(/^posts\//, '')}/${file.name === 'index' ? '' : file.name}`
-)
-
-export const getClassNameFromArticleFile = (file: ArticleFile): string => (
-  [
-    'page',
-    file.directory.replace(/^posts\//, '').replace(/\//g, '-'),
-    ...(file.name === 'index' ? [] : [ file.name ]),
-  ].join('-')
+export const getClassNameFromPath = (path: string): string => (
+  'page' + path.replace(/\//g, '-').replace(/-$/, '')
 )
 
 const ArticleHeaderAttributes = styled.p`
@@ -119,7 +111,7 @@ const Article = injectIntl<ArticleProps>(function Article({
   children,
   components = {},
   article: {
-    file,
+    path,
     attributes: {
       title,
       created,
@@ -138,11 +130,9 @@ const Article = injectIntl<ArticleProps>(function Article({
     formatDate,
   },
 }) {
-  const path = getPathFromArticleFile(file)
-
   return (
     <>
-      <ArticleContainer className={getClassNameFromArticleFile(file)}>
+      <ArticleContainer className={getClassNameFromPath(path)}>
         <ArticleHeader title={<Link to={path}>{title}</Link>}>
           <ArticleHeaderAttributes>
             {category ? (
@@ -204,8 +194,8 @@ const Article = injectIntl<ArticleProps>(function Article({
           <PaginationContainer>
             <SimplePagination
               className="simple-pagination"
-              prev={prev ? { title: prev.attributes.title, to: getPathFromArticleFile(prev.file) } : null}
-              next={next ? { title: next.attributes.title, to: getPathFromArticleFile(next.file) } : null}
+              prev={prev ? { title: prev.attributes.title, to: prev.path } : null}
+              next={next ? { title: next.attributes.title, to: next.path } : null}
             />
           </PaginationContainer>
         </ArticleContainer>
@@ -223,7 +213,7 @@ interface ArticleItemBase {
     tags?: (ArticleTagItem | null)[]
     navigation?: NavigationLinkItem[] | null
   }
-  file: ArticleFile
+  path: string
   htmlAst?: {}
   excerptAst?: {}
   excerpted: boolean
@@ -238,11 +228,6 @@ export interface ExcerptedArticleItem extends ArticleItemBase {
 }
 
 export type ArticleItem = FullArticleItem | ExcerptedArticleItem
-
-interface ArticleFile {
-  directory: string
-  name: string
-}
 
 export interface ArticleCategoryItem {
   name: string

--- a/src/components/Sidebar/index.tsx
+++ b/src/components/Sidebar/index.tsx
@@ -14,7 +14,7 @@ import {
   HatenaShareButton,
   TumblrShareButton,
 } from './buttons'
-import { ArticleItem, getPathFromArticleFile } from 'components/Article'
+import { ArticleItem } from 'components/Article'
 import { NavigationLinkItem } from 'components/Navbar'
 import { withMetadata } from 'components/Metadata'
 import { media } from 'components/Layout'
@@ -45,6 +45,7 @@ const query = graphql`
     ) {
       items: edges {
         article: node {
+          path
           attributes: frontmatter {
             title
             created
@@ -52,7 +53,6 @@ const query = graphql`
               ...Category
             }
           }
-          ...File
         }
       }
     }
@@ -239,7 +239,7 @@ const Sidebar = injectIntl<{}>(withMetadata(function Sidebar({
           {latest.items.map(({ article }, index) => (
             <li className="iconless" key={index}>
               <SidebarItemListIcon name="coffee" />
-              <Link to={getPathFromArticleFile(article.file)}>
+              <Link to={article.path}>
                 {article.attributes.title}
               </Link>
               <br />

--- a/src/pages/latest.tsx
+++ b/src/pages/latest.tsx
@@ -24,7 +24,6 @@ export const pageQuery = graphql`
           excerptAst
           excerpted
           ...Article
-          ...File
         }
       }
     }

--- a/src/templates/article.tsx
+++ b/src/templates/article.tsx
@@ -10,7 +10,7 @@ import Header from 'components/Header'
 import Navbar from 'components/Navbar'
 import Content from 'components/Content'
 import Footer from 'components/Footer'
-import Article, { ArticleItem, getPathFromArticleFile } from 'components/Article'
+import Article, { ArticleItem } from 'components/Article'
 
 export const pageQuery = graphql`
   query article($id: String!, $prev: String, $next: String) {
@@ -32,7 +32,7 @@ export const pageQuery = graphql`
     }
   }
   fragment Article on MarkdownRemark {
-    ...File
+    path
     excerpted
     attributes: frontmatter {
       title
@@ -58,15 +58,6 @@ export const pageQuery = graphql`
     name
     path
     thumbnail
-  }
-  fragment FileNode on File {
-    directory: relativeDirectory
-    name
-  }
-  fragment File on Node {
-    file: parent {
-      ...FileNode
-    }
   }
 `
 
@@ -126,7 +117,7 @@ const ArticlePage: FunctionComponent<ArticlePageProps> = ({
           'position': 3,
           'item': {
             '@type': 'Thing',
-            'id': siteUrl + getPathFromArticleFile(article.file),
+            'id': siteUrl + article.path,
             'name': article.attributes.title,
           },
         },
@@ -145,7 +136,7 @@ const ArticlePage: FunctionComponent<ArticlePageProps> = ({
           'position': 2,
           'item': {
             '@type': 'Thing',
-            'id': siteUrl + getPathFromArticleFile(article.file),
+            'id': siteUrl + article.path,
             'name': article.attributes.title,
           },
         },


### PR DESCRIPTION
Moves directory-based path creation to plugin and expose as a GraphQL field.

This PR adds the following field:

```graphql
{
  allMarkdownRemark {
    nodes {
      # represents the path for an article that starts with /
      path
    }
  }
}
```