### PR TITLE
Replace <a> elements directly by rehype-react

### DIFF
--- a/plugins/historia-remark-plugin/index.js
+++ b/plugins/historia-remark-plugin/index.js
@@ -1,7 +1,6 @@
 const cheerio = require('cheerio')
 const visit = require('unist-util-visit-parents')
 const definitions = require('mdast-util-definitions')
-const modifyChildren = require('unist-util-modify-children')
 const attributesToProps = require('html-react-parser/lib/attributes-to-props')
 
 module.exports = ({
@@ -21,40 +20,6 @@ module.exports = ({
         children: $('img'),
       })
     }
-  })
-
-  // Traverse through Markdown links
-  visit(markdownAST, ['link', 'linkReference'], (node, ancestors) => {
-    const parent = ancestors[ancestors.length - 1]
-
-    modifyChildren((node, index, parent) => {
-      const ctx = node.type === 'link' ? node : definition(node.identifier)
-      if (!ctx || (ctx.data && ctx.data.hProperties && ctx.data.hProperties['aria-label'])) {
-        return
-      }
-
-      // Create <historia-link /> and split them to open and close tag
-      const $ = cheerio.load('');
-      const [ , open, close ] = $('body').append(
-        $('<historia-link />').attr({
-          to: ctx.url,
-          ...(ctx.data && ctx.data.hProperties || {}),
-        })
-      ).html().match(/(.*)(<\/.*)/)
-
-      // Replace a Markdown link with <historia-link />
-      parent.children.splice(index, 1,
-        {
-          type: 'html',
-          value: open,
-        },
-        ...(node.children || []),
-        {
-          type: 'html',
-          value: close,
-        },
-      )
-    })(parent)
   })
 
   // Replace <img /> with <historia-image />

--- a/plugins/historia-remark-plugin/package.json
+++ b/plugins/historia-remark-plugin/package.json
@@ -5,7 +5,6 @@
     "cheerio": "^1.0.0-rc.3",
     "html-react-parser": "^0.9.1",
     "mdast-util-definitions": "^1.2.4",
-    "unist-util-modify-children": "^1.1.4",
     "unist-util-visit-parents": "^2.1.2"
   }
 }

--- a/src/components/Article/index.tsx
+++ b/src/components/Article/index.tsx
@@ -151,7 +151,7 @@ const Article = injectIntl<ArticleProps>(function Article({
     'pspsdk-function': PspSdkFunction,
     'pspsdk-macro': PspSdkMacro,
     'historia-image': ImageZoomWrapper,
-    'historia-link': Link,
+    a: Link,
   })
 
   return (

--- a/src/components/Link/index.tsx
+++ b/src/components/Link/index.tsx
@@ -1,17 +1,29 @@
-import React, { FunctionComponent } from 'react'
+import React, { FunctionComponent, DetailedHTMLProps, AnchorHTMLAttributes } from 'react'
 import isUrl from 'is-url'
 import GatsbyLink, { GatsbyLinkProps } from 'gatsby-link'
 
-const Link: FunctionComponent<GatsbyLinkProps<{}>> = ({
+const isAnchor = (to: string) => to.startsWith('#')
+
+const Link: FunctionComponent<GatsbyLinkProps<{}> & LinkProps> = function Link({
   to,
+  href,
   children,
   ref,
   target,
   ...rest
-}) => (to && isUrl(to) || target) ? (
-  <a href={to} ref={ref} target={target || '_blank'} rel="nofollow noopener noreferrer" {...rest}>{children}</a>
-) : (
-  <GatsbyLink to={to} {...rest}>{children}</GatsbyLink>
-)
+}) {
+  const dest = to || href || ''
+  return isUrl(dest) || target ? (
+    <a href={dest} ref={ref} target={target || '_blank'} rel="nofollow noopener noreferrer" {...rest}>{children}</a>
+  ) : isAnchor(dest) ? (
+    <a href={dest} ref={ref} {...rest}>{children}</a>
+  ) : (
+    <GatsbyLink to={dest} {...rest}>{children}</GatsbyLink>
+  )
+}
+
+interface LinkProps extends DetailedHTMLProps<AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement> {
+  to?: string
+}
 
 export default Link

--- a/yarn.lock
+++ b/yarn.lock
@@ -14135,7 +14135,7 @@ unist-util-is@^3.0.0:
   resolved "https://registry.yarnpkg.com/unist-util-is/-/unist-util-is-3.0.0.tgz#d9e84381c2468e82629e4a5be9d7d05a2dd324cd"
   integrity sha512-sVZZX3+kspVNmLWBPAB6r+7D9ZgAFPNWm66f7YNb420RlQSbn+n8rG8dGZSkrER7ZIXGQYNm5pqC3v3HopH24A==
 
-unist-util-modify-children@^1.0.0, unist-util-modify-children@^1.1.4:
+unist-util-modify-children@^1.0.0:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/unist-util-modify-children/-/unist-util-modify-children-1.1.4.tgz#f9dd31e93884c3be06b43c9291d60324d5df5f68"
   integrity sha512-8iey9wkoB62C7Vi/8zcRUmi4b1f5AYKTwMkyEgLduo2D8+OY65RoSvbn6k9tVNri6qumXxAwXDVlXWQi0sENTw==


### PR DESCRIPTION
Removes the procedure for replaing `<a>` elements with `Link` components and yields all to rehype-react.