### PR TITLE
Update CI/CD to fail when deployment errored

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: node_js
 node_js:
   - '12'
 
+dist: bionic
 env:
   global:
     - TZ=Asia/Tokyo

--- a/.travis/after_success
+++ b/.travis/after_success
@@ -1,11 +1,25 @@
 #!/usr/bin/env bash
 
-if [[ "$TRAVIS_BRANCH" = 'master' ]] && [[ "$TRAVIS_PULL_REQUEST" = 'false' ]]; then
+if [[ $TRAVIS_BRANCH = 'master' ]] && [[ $TRAVIS_PULL_REQUEST = 'false' ]]; then
     echo 'Cleaning...'
     ssh deploy rm -rf /srv/http/vhosts/chitoku.jp/historia/*
-    echo 'Cleaned!'
+    status=$?
+
+    if (( $status )); then
+        echo 'Failed to clean the remote files.' >&2
+        exit $status
+    else
+        echo 'Cleaned!'
+    fi
 
     echo 'Uploading...'
     rsync -rz public/ deploy:/srv/http/vhosts/chitoku.jp/historia
-    echo 'Uploaded!'
+    status=$?
+
+    if (( $status )); then
+        echo 'Failed to upload.' >&2
+        exit $status
+    else
+        echo 'Uploaded!'
+    fi
 fi

--- a/.travis/before_install
+++ b/.travis/before_install
@@ -3,7 +3,7 @@
 # Install the latest version of yarn
 # See also: https://docs.travis-ci.com/user/languages/javascript-with-nodejs/#using-a-specific-yarn-version
 curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.19.0
-export PATH="$HOME/.yarn/bin:$PATH"
+export PATH=$HOME/.yarn/bin:$PATH
 
 # Install full-icu
 # See also: https://github.com/nodejs/help/issues/832
@@ -13,4 +13,4 @@ export NODE_ICU_DATA=$(node-full-icu-path)
 # Install reviewdog
 mkdir -p ~/.bin
 curl -sfL https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh | bash -s -- -b ~/.bin
-export PATH="~/.bin/:$PATH"
+export PATH=~/.bin/:$PATH

--- a/.travis/before_script
+++ b/.travis/before_script
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-if [[ "$TRAVIS_BRANCH" = 'master' ]] && [[ "$TRAVIS_PULL_REQUEST" = 'false' ]]; then
+if [[ $TRAVIS_BRANCH = 'master' ]] && [[ $TRAVIS_PULL_REQUEST = 'false' ]]; then
     openssl aes-256-cbc -K "$encrypted_2ff73684a3eb_key" -iv "$encrypted_2ff73684a3eb_iv" -in .travis/ssh.tar.enc -out ssh.tar -d
     tar xvf ssh.tar
     mv id_ed25519 config ~/.ssh


### PR DESCRIPTION
The CI/CD pipeline has failed in uploading resources due to its dependency (zlib). Trying with the newer container environment...

```
Uploading...
rsync: This rsync lacks old-style --compress due to its external zlib.  Try -zz.
rsync error: syntax or usage error (code 1) at main.c(1578) [server=3.1.3]
rsync: connection unexpectedly closed (0 bytes received so far) [sender]
rsync error: error in rsync protocol data stream (code 12) at io.c(226) [sender=3.1.1]
Uploaded!
```