### PR TITLE
Remove gitAuthor from schema

### DIFF
--- a/schema.gql
+++ b/schema.gql
@@ -74,7 +74,6 @@ type GitCommit implements Node {
     locale: String
   ): Date!
   latest: Boolean!
-  author: GitAuthor!
 }
 type HomeYaml implements Node {
   items: [HomeYamlItems!]!


### PR DESCRIPTION
Not sure why this line triggered deprecation warning.