### PR TITLE
Uninstall @babel/plugin-transform-typescript

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -4,7 +4,6 @@
     ["@babel/preset-env"]
   ],
   "plugins": [
-    ["@babel/plugin-transform-typescript"],
     ["@babel/plugin-transform-runtime"],
     ["@babel/plugin-proposal-class-properties"],
     ["react-intl-auto", { "removePrefix": "src/" }],

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "@babel/core": "^7.9.6",
     "@babel/plugin-proposal-class-properties": "^7.8.3",
     "@babel/plugin-transform-runtime": "^7.9.6",
-    "@babel/plugin-transform-typescript": "^7.9.6",
     "@babel/preset-env": "^7.9.6",
     "@rstacruz/gatsby-remark-component": "^2.0.0",
     "@types/algoliasearch": "^3.34.10",

--- a/plugins/historia-compat-plugin/gatsby-node.js
+++ b/plugins/historia-compat-plugin/gatsby-node.js
@@ -14,6 +14,7 @@ exports.onCreateWebpackConfig = ({
         {
           test: /\.m?js$/u,
           include: [
+            path.join(path.resolve('node_modules/@pmmmwh/react-refresh-webpack-plugin'), '/'),
             path.join(path.resolve('node_modules/@weknow/gatsby-remark-twitter'), '/'),
             path.join(path.resolve('node_modules/react'), '/'),
             path.join(path.resolve('node_modules/react-intl'), '/'),

--- a/yarn.lock
+++ b/yarn.lock
@@ -234,7 +234,7 @@
     levenary "^1.1.1"
     semver "^5.5.0"
 
-"@babel/helper-create-class-features-plugin@^7.8.3", "@babel/helper-create-class-features-plugin@^7.9.6":
+"@babel/helper-create-class-features-plugin@^7.8.3":
   version "7.9.6"
   resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.9.6.tgz#965c8b0a9f051801fd9d3b372ca0ccf200a90897"
   integrity sha512-6N9IeuyHvMBRyjNYOMJHrhwtu4WJMrYf8hVbEHD3pbbbmNOk1kmXSQs7bA4dYDUaIx4ZEzdnvo6NwC3WHd/Qow==
@@ -628,13 +628,6 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.3"
 
-"@babel/plugin-syntax-typescript@^7.8.3":
-  version "7.8.3"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.8.3.tgz#c1f659dda97711a569cef75275f7e15dcaa6cabc"
-  integrity sha512-GO1MQ/SGGGoiEXY0e0bSpHimJvxqB7lktLLIq2pv8xG7WZ8IMEle74jIe1FhprHBWjwjZtXHkycDLZXIWM5Wfg==
-  dependencies:
-    "@babel/helper-plugin-utils" "^7.8.3"
-
 "@babel/plugin-transform-arrow-functions@^7.0.0", "@babel/plugin-transform-arrow-functions@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.8.3.tgz#82776c2ed0cd9e1a49956daeb896024c9473b8b6"
@@ -939,15 +932,6 @@
   integrity sha512-2QKyfjGdvuNfHsb7qnBBlKclbD4CfshH2KvDabiijLMGXPHJXGxtDzwIF7bQP+T0ysw8fYTtxPafgfs/c1Lrqg==
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.3"
-
-"@babel/plugin-transform-typescript@^7.9.6":
-  version "7.9.6"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.9.6.tgz#2248971416a506fc78278fc0c0ea3179224af1e9"
-  integrity sha512-8OvsRdvpt3Iesf2qsAn+YdlwAJD7zJ+vhFZmDCa4b8dTp7MmHtKk5FF2mCsGxjZwuwsy/yIIay/nLmxST1ctVQ==
-  dependencies:
-    "@babel/helper-create-class-features-plugin" "^7.9.6"
-    "@babel/helper-plugin-utils" "^7.8.3"
-    "@babel/plugin-syntax-typescript" "^7.8.3"
 
 "@babel/plugin-transform-unicode-regex@^7.8.3":
   version "7.8.3"


### PR DESCRIPTION
Removes a package that is no longer necessary.