### PR TITLE
Use babel-preset-gatsby target for compatibility

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,11 +1,13 @@
 {
   "presets": [
-    ["gatsby"],
-    ["@babel/preset-env"]
+    ["gatsby", {
+      "targets": {
+        "browsers": ["> 3% in JP"]
+      }
+    }]
   ],
   "plugins": [
-    ["@babel/plugin-transform-runtime"],
-    ["@babel/plugin-proposal-class-properties"],
+    ["@babel/plugin-transform-typescript"],
     ["react-intl-auto", { "removePrefix": "src/" }],
     ["styled-components"]
   ]

--- a/package.json
+++ b/package.json
@@ -4,10 +4,7 @@
   "author": "ちとく <odango@chitoku.jp>",
   "description": "ちとくのホームページ",
   "devDependencies": {
-    "@babel/core": "^7.9.6",
-    "@babel/plugin-proposal-class-properties": "^7.8.3",
-    "@babel/plugin-transform-runtime": "^7.9.6",
-    "@babel/preset-env": "^7.9.6",
+    "@babel/plugin-transform-typescript": "^7.9.6",
     "@rstacruz/gatsby-remark-component": "^2.0.0",
     "@types/is-url": "^1.2.28",
     "@types/prismjs": "^1.16.1",
@@ -124,8 +121,5 @@
     "plugins/historia-recotw-plugin",
     "plugins/historia-soarer-update-plugin",
     "plugins/historia-taxonomy-plugin"
-  ],
-  "browserslist": [
-    "> 3% in JP"
   ]
 }

--- a/plugins/historia-compat-plugin/gatsby-browser.js
+++ b/plugins/historia-compat-plugin/gatsby-browser.js
@@ -1,11 +1,6 @@
 'use strict'
 
 /* eslint-disable global-require */
-// https://www.gatsbyjs.org/docs/browser-support/
-// https://www.npmjs.com/package/babel-preset-gatsby
 exports.onClientEntry = () => {
-  require('core-js/fn/array/flat-map')
-  require('core-js/fn/array/from')
-  require('core-js/modules/es6.symbol')
   require('whatwg-fetch')
 }

--- a/translations/ja.yml
+++ b/translations/ja.yml
@@ -1,80 +1,80 @@
 components:
-  Mail:
-    mail: メールアドレス
-    name: お名前
-    send: 送信
-    about: プロフィール
-    title: メール
-    message: メッセージ
-    subject: 件名
-    required: （必須）
-    submission_error: メールの送信ができませんでした
-    contact_me_on_sns: SNS でのご連絡の場合、より早くお返事できるかもしれません。
-    submission_accepted: メールの送信を受け付けました
-    contact_me_from_about: 'アカウントは{about}からご覧いただけます。'
-    submission_processing: 送信しています……
   About:
     icon: 'Icon by {name}'
+    interests: 興味
+    introduction: 自己紹介
     mail: メール
     name: 名前
-    title: プロフィール
-    interests: 興味
     occupation: 職業
-    introduction: 自己紹介
-  Links:
-    title: リンク
+    title: プロフィール
   Article:
     more: 続きを読む »
+  Footer:
+    copyright: '© Chitoku 2014 ({link})'
   Latest:
     title: 最近の投稿
-  NotFound:
-    try: 次の方法をお試しください。
-    home: トップページ
-    title: ページがありません
-    give_up: あきらめる
-    requested: 'リクエストされた URL: {url}'
-    go_to_home: '{home}に移動する'
-    description: お探しのページが見つかりませんでした。URL が変更された、または削除された可能性があります。ご不便をおかけして申し訳ありません。
-    follow_me_on: '{service} で {account} をフォローする'
-    administrator: 管理人
-    complain_to_administrator: '{administrator}に文句を言う'
-  Sidebar:
-    links: 投稿リンク
-    share: 共有
-    hatena: はてなブックマーク
-    pocket: Pocket
-    tumblr: Tumblr
-    twitter: Twitter
-    facebook: Facebook
-    share_on: '{service} で共有'
-    latest_articles: 最近の投稿
+  Links:
+    title: リンク
+  Mail:
+    about: プロフィール
+    contact_me_from_about: 'アカウントは{about}からご覧いただけます。'
+    contact_me_on_sns: SNS でのご連絡の場合、より早くお返事できるかもしれません。
+    mail: メールアドレス
+    message: メッセージ
+    name: お名前
+    required: （必須）
+    send: 送信
+    subject: 件名
+    submission_accepted: メールの送信を受け付けました
+    submission_error: メールの送信ができませんでした
+    submission_processing: 送信しています……
+    title: メール
   Metadata:
     title: ちとくのホームページ
     title_template: '{title} – ちとくのホームページ'
+  NotFound:
+    administrator: 管理人
+    complain_to_administrator: '{administrator}に文句を言う'
+    description: お探しのページが見つかりませんでした。URL が変更された、または削除された可能性があります。ご不便をおかけして申し訳ありません。
+    follow_me_on: '{service} で {account} をフォローする'
+    give_up: あきらめる
+    go_to_home: '{home}に移動する'
+    home: トップページ
+    requested: 'リクエストされた URL: {url}'
+    title: ページがありません
+    try: 次の方法をお試しください。
   Pagination:
     next: »
-    prev: «
     next_page: 次へ »
+    prev: «
     prev_page: « 前へ
-  Footer:
-    copyright: '© Chitoku 2014 ({link})'
+  PspErrorCodes:
+    description: 説明
+    error_code: エラー番号
   SearchForm:
     cancel: キャンセル
-    search: 検索
     enable_javascript: 検索を利用するためには、JavaScript の設定を有効にしてください
+    search: 検索
   SearchResult:
-    title: 検索
-    not_found: '{text} を含む記事が見つかりませんでした。'
-    title_text: '検索結果: {text}'
-    how_to_search: 検索したいキーワードを入力してください。
-    breadcrumb_path: 'https://chitoku.jp{path}'
-    not_found_hints: 記事のタイトル、カテゴリー、タグ、本文冒頭のみが検索の対象です。
     breadcrumb_category: 'https://chitoku.jp › {category}'
+    breadcrumb_path: 'https://chitoku.jp{path}'
+    how_to_search: 検索したいキーワードを入力してください。
+    not_found: '{text} を含む記事が見つかりませんでした。'
+    not_found_hints: 記事のタイトル、カテゴリー、タグ、本文冒頭のみが検索の対象です。
+    title: 検索
+    title_text: '検索結果: {text}'
+  Sidebar:
+    facebook: Facebook
+    hatena: はてなブックマーク
+    latest_articles: 最近の投稿
+    links: 投稿リンク
+    pocket: Pocket
+    share: 共有
+    share_on: '{service} で共有'
+    tumblr: Tumblr
+    twitter: Twitter
   SoarerDownload:
-    history: 更新履歴 ▶
     download: 'ダウンロード ({size})'
+    history: 更新履歴 ▶
   SoarerHistory:
     download: ダウンロード
-  PspErrorCodes:
-    error_code: エラー番号
-    description: 説明

--- a/yarn.lock
+++ b/yarn.lock
@@ -933,7 +933,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.3"
 
-"@babel/plugin-transform-typescript@^7.9.0":
+"@babel/plugin-transform-typescript@^7.9.0", "@babel/plugin-transform-typescript@^7.9.6":
   version "7.9.6"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.9.6.tgz#2248971416a506fc78278fc0c0ea3179224af1e9"
   integrity sha512-8OvsRdvpt3Iesf2qsAn+YdlwAJD7zJ+vhFZmDCa4b8dTp7MmHtKk5FF2mCsGxjZwuwsy/yIIay/nLmxST1ctVQ==


### PR DESCRIPTION
1. This project does not directly have to depend on the following packages:
- `@babel/core`
- `@babel/plugin-proposal-class-properties`
- `@babel/plugin-transform-runtime`
- `@babel/preset-env`
2. The following package has accidentally been removed but still required for i18n generator:
- `@babel/plugin-transform-typescript`