### PR TITLE
Fix weird popup in React Developer Tools

### DIFF
--- a/src/styles/styles.scss
+++ b/src/styles/styles.scss
@@ -14,8 +14,8 @@ body {
   background: #efefef;
   word-wrap: break-word;
   &,
-  > div#___gatsby,
-  > div > div {
+  div#___gatsby,
+  div#gatsby-focus-wrapper {
     height: 100%;
   }
 }


### PR DESCRIPTION
The description below affected React Developer Tools:
```css
body > div > div {
    height: 100%;
}
```
<img src="https://user-images.githubusercontent.com/6535425/82735771-2bc4e780-9d5f-11ea-9e20-430c3fcd3841.png" width="392">
↓
<img src="https://user-images.githubusercontent.com/6535425/82735805-70508300-9d5f-11ea-9e4b-dda829570c63.png" width="395">

