### PR TITLE
Fix /softwares/superflat not being deployed

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -11,6 +11,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
+        with:
+          submodules: true
       - name: Extract .env
         run: echo "$ENVFILE" > .env
         env:


### PR DESCRIPTION
Even ancient software have to be deployed however useless the feature is now.