### PR TITLE
Fix Sidebar items in IE

### DIFF
--- a/src/components/NavItem/index.tsx
+++ b/src/components/NavItem/index.tsx
@@ -37,8 +37,8 @@ const Dropdown = styled(BootstrapDropdown)`
     }
   }
   .sub-menu {
-    position: initial !important;
-    opacity: initial !important;
+    position: static !important;
+    opacity: 1 !important;
     pointer-events: initial !important;
   }
   .sub-toggle,


### PR DESCRIPTION
Fixes submenu in sidebar where IE doesn't support CSS value `initial`.

Before:
<img src="https://user-images.githubusercontent.com/6535425/87221970-f6c23200-c3aa-11ea-9c14-a6e9b5b21036.png" width="350">

After:
<img src="https://user-images.githubusercontent.com/6535425/87221930-b4005a00-c3aa-11ea-86e4-776732d694bf.png" width="350">
