### PR TITLE
Fix icons before latest items in IE

### DIFF
--- a/src/components/Sidebar/index.tsx
+++ b/src/components/Sidebar/index.tsx
@@ -142,6 +142,7 @@ const LatestItem = styled.li`
 
 const LatestItemIcon = styled(FontAwesomeIcon)`
   margin-top: 4px;
+  flex-shrink: 0;
 `
 
 const LatestItemBody = styled.div`


### PR DESCRIPTION
IE thinks differently from the other browsers as to how flex items consume their widths inside a container.

Before:
<img src="https://user-images.githubusercontent.com/6535425/87222267-62a59a00-c3ad-11ea-86c9-26e258cc8350.png" width="345">

After:
<img src="https://user-images.githubusercontent.com/6535425/87222260-57526e80-c3ad-11ea-918d-4a583c3d8a1e.png" width="345">
