### PR TITLE
Prevent Prism.js from flickering when page loads

### DIFF
--- a/gatsby-browser.ts
+++ b/gatsby-browser.ts
@@ -1,4 +1,5 @@
 import { GatsbyBrowser } from 'gatsby'
+import Prism from 'prismjs'
 import twemoji from 'twemoji'
 
 export const onRouteUpdate: GatsbyBrowser['onRouteUpdate'] = () => {
@@ -6,6 +7,10 @@ export const onRouteUpdate: GatsbyBrowser['onRouteUpdate'] = () => {
   if (el) {
     twemoji.parse(el)
   }
+}
+
+export const onClientEntry: GatsbyBrowser['onClientEntry'] = () => {
+  Prism.manual = true
 }
 
 export const onInitialClientRender: GatsbyBrowser['onInitialClientRender'] = () => {

--- a/src/components/PspSdkFunction/index.tsx
+++ b/src/components/PspSdkFunction/index.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, useEffect, useRef } from 'react'
+import React, { FunctionComponent } from 'react'
 import clsx from 'clsx'
 import Prism from 'prismjs'
 import 'prismjs/components/prism-c'
@@ -21,13 +21,6 @@ const PspSdkFunction: FunctionComponent<PspSdkFunctionProps> = ({
   article,
   name: functionName,
 }) => {
-  const ref = useRef<HTMLDivElement>(null)
-  useEffect(() => {
-    if (ref.current) {
-      Prism.highlightElement(ref.current)
-    }
-  }, [ ref ])
-
   const def = article.attributes.functions?.find(x => x?.name === functionName)
   if (!def) {
     return null
@@ -35,18 +28,20 @@ const PspSdkFunction: FunctionComponent<PspSdkFunctionProps> = ({
 
   const separator = def.parameters?.length && def.parameters.length > linebreakThreshold ? '\n' : ''
   const indentation = separator ? ' '.repeat(indentationWidth) : ''
+  const highlighted = Prism.highlight([
+    `${def.return} ${def.name}(`,
+    def.parameters
+      ? def.parameters.map(x => buildParameters(x, indentation)).join(`, ${separator}`)
+      : 'void',
+    ');',
+  ].join(separator), Prism.languages.c, 'c')
 
+  /* eslint-disable react/no-danger */
   return (
     <div className={styles.entry}>
-      <code className={clsx(styles.prototype, 'language-c')} ref={ref}>
-        {[
-          `${def.return} ${def.name}(`,
-          def.parameters
-            ? def.parameters.map(x => buildParameters(x, indentation)).join(`, ${separator}`)
-            : 'void',
-          ');',
-        ].join(separator)}
-      </code>
+      <pre className={clsx(styles.prototype, 'language-c')}>
+        <code className="language-c" dangerouslySetInnerHTML={{ __html: highlighted }} />
+      </pre>
       <div className={styles.description}>
         {def.description}
         {def.parameters ? (

--- a/src/components/PspSdkFunction/styles.module.scss
+++ b/src/components/PspSdkFunction/styles.module.scss
@@ -14,11 +14,10 @@
 }
 
 .prototype {
-  display: block;
+  display: block !important;
   padding: 4px 8px !important;
-  margin-top: 4px !important;
-  margin-bottom: 4px !important;
-  overflow-x: auto;
+  margin: 4px 0 !important;
+  overflow-x: auto !important;
   white-space: pre !important;
   -webkit-overflow-scrolling: touch;
 }

--- a/src/components/PspSdkMacro/index.tsx
+++ b/src/components/PspSdkMacro/index.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, useEffect, useRef } from 'react'
+import React, { FunctionComponent } from 'react'
 import clsx from 'clsx'
 import Prism from 'prismjs'
 import 'prismjs/components/prism-c'
@@ -19,13 +19,6 @@ const PspSdkMacro: FunctionComponent<PspSdkMacroProps> = ({
   article,
   name: macroName,
 }) => {
-  const ref = useRef<HTMLElement>(null)
-  useEffect(() => {
-    if (ref.current) {
-      Prism.highlightElement(ref.current)
-    }
-  }, [ ref ])
-
   const def = article.attributes.macros?.find(x => x?.name === macroName)
   if (!def) {
     return null
@@ -33,16 +26,18 @@ const PspSdkMacro: FunctionComponent<PspSdkMacroProps> = ({
 
   const separator = def.parameters?.length && def.parameters.length > linebreakThreshold ? '\n' : ''
   const indentation = separator ? ' '.repeat(indentationWidth) : ''
+  const highlighted = Prism.highlight([
+    `${def.name}(`,
+    def.parameters?.map(x => buildParameters(x, indentation)).join(`, ${separator}`) ?? '',
+    ');',
+  ].join(separator), Prism.languages.c, 'c')
 
+  /* eslint-disable react/no-danger */
   return (
     <div className={styles.entry}>
-      <code className={clsx(styles.prototype, 'language-c')} ref={ref}>
-        {[
-          `${def.name}(`,
-          def.parameters?.map(x => buildParameters(x, indentation)).join(`, ${separator}`) ?? '',
-          ');',
-        ].join(separator)}
-      </code>
+      <pre className={clsx(styles.prototype, 'language-c')}>
+        <code className="language-c" dangerouslySetInnerHTML={{ __html: highlighted }} />
+      </pre>
       <div className={styles.description}>
         {def.description}
         {def.parameters ? (

--- a/src/components/PspSdkMacro/styles.module.scss
+++ b/src/components/PspSdkMacro/styles.module.scss
@@ -14,11 +14,10 @@
 }
 
 .prototype {
-  display: block;
+  display: block !important;
   padding: 4px 8px !important;
-  margin-top: 4px !important;
-  margin-bottom: 4px !important;
-  overflow-x: auto;
+  margin: 4px 0 !important;
+  overflow-x: auto !important;
   white-space: pre !important;
   -webkit-overflow-scrolling: touch;
 }

--- a/typings/prismjs-components.d.ts
+++ b/typings/prismjs-components.d.ts
@@ -1,1 +1,5 @@
 declare module 'prismjs/components/prism-c'
+declare namespace Prism {
+  /* eslint-disable @typescript-eslint/init-declarations */
+  export let manual: boolean
+}


### PR DESCRIPTION
## `Prism.manual`

Prism.js defaults to pick `language-*` elements and rerenders them on `DOMContentLoaded` and that prevented the page to stay the same. That operation is useless since the pages are basically prerendered in server side. Enabling `manual` can resolve this problem as it no longer triggers this hook.

## `PspSdkFunction` and `PspSdkMacro`

Those components used `useRef()` and triggered `Prism.highlightElement()` targeting their underlying DOM elements in runtime, which are known to prevent them from being server-side rendered. It is now fixed as it passes the highlighted result to `dangerouslySetInnerHTML`.