### PR TITLE
Parse twemoji in AST phase

### DIFF
--- a/gatsby-browser.ts
+++ b/gatsby-browser.ts
@@ -1,13 +1,5 @@
 import { GatsbyBrowser } from 'gatsby'
 import Prism from 'prismjs'
-import twemoji from 'twemoji'
-
-export const onRouteUpdate: GatsbyBrowser['onRouteUpdate'] = () => {
-  const el = document.getElementById('___gatsby')
-  if (el) {
-    twemoji.parse(el)
-  }
-}
 
 export const onClientEntry: GatsbyBrowser['onClientEntry'] = () => {
   Prism.manual = true

--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -160,6 +160,7 @@ const config: GatsbyConfig = {
               ],
             },
           },
+          { resolve: 'historia-remark-plugin' },
         ],
       },
     },

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "@types/react-instantsearch-core": "^6.3.0",
     "@types/react-instantsearch-dom": "^6.3.0",
     "@types/sass": "^1.16.0",
-    "@types/twemoji": "^12.1.1",
     "@typescript-eslint/eslint-plugin": "^3.9.0",
     "@typescript-eslint/parser": "^3.9.0",
     "algoliasearch": "^4.4.0",
@@ -92,7 +91,6 @@
     "stylelint-scss": "^3.18.0",
     "ts-node": "^8.10.2",
     "tsconfig-paths-webpack-plugin": "^3.3.0",
-    "twemoji": "^13.0.1",
     "typescript": "^3.9.7",
     "use-media": "^1.4.0",
     "webpack": "^4.44.1",
@@ -129,6 +127,7 @@
     "plugins/historia-compat-plugin",
     "plugins/historia-feed-plugin",
     "plugins/historia-recotw-plugin",
+    "plugins/historia-remark-plugin",
     "plugins/historia-soarer-update-plugin",
     "plugins/historia-taxonomy-plugin"
   ]

--- a/plugins/historia-remark-plugin/index.ts
+++ b/plugins/historia-remark-plugin/index.ts
@@ -1,0 +1,38 @@
+import { Node } from 'unist'
+import u from 'unist-builder'
+import { selectAll } from 'unist-util-select'
+import remove from 'unist-util-remove'
+import visit from 'unist-util-visit'
+import twemoji from 'twemoji'
+
+interface RemarkPluginArgs {
+  markdownAST: RemarkNode
+  compiler: {
+    generateHTML: (ast: RemarkNode) => string
+  }
+}
+
+interface RemarkNode extends Node {
+  children?: RemarkNode[]
+  value?: string
+}
+
+export default ({
+  markdownAST,
+  compiler: {
+    generateHTML,
+  },
+}: RemarkPluginArgs): void => {
+  markdownAST.children?.push(
+    u('text', '\n'),
+    u('html', generateHTML(u('root', selectAll('footnoteDefinition', markdownAST)))),
+  )
+  remove(markdownAST, 'footnoteDefinition')
+
+  visit<RemarkNode>(markdownAST, [ 'text', 'html' ], node => {
+    if (node.value && twemoji.test(node.value)) {
+      node.type = 'html'
+      node.value = twemoji.parse(node.value)
+    }
+  })
+}

--- a/plugins/historia-remark-plugin/package.json
+++ b/plugins/historia-remark-plugin/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "historia-remark-plugin",
+  "version": "1.0.0",
+  "dependencies": {
+    "@types/twemoji": "^12.1.1",
+    "twemoji": "^13.0.1",
+    "unist-builder": "^2.0.3",
+    "unist-util-remove": "^2.0.0",
+    "unist-util-select": "^3.0.1",
+    "unist-util-visit": "^2.0.3"
+  }
+}

--- a/typings/unist-util-remove.d.ts
+++ b/typings/unist-util-remove.d.ts
@@ -1,0 +1,9 @@
+import { Node } from 'unist'
+import { Test } from 'unist-util-is'
+
+declare function remove<T extends Node>(
+  tree: T,
+  test?: Test<T>,
+): Node | null
+
+export = remove

--- a/yarn.lock
+++ b/yarn.lock
@@ -5943,6 +5943,11 @@ css-select@^2.0.0:
     domutils "^1.7.0"
     nth-check "^1.0.2"
 
+css-selector-parser@^1.0.0:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/css-selector-parser/-/css-selector-parser-1.4.1.tgz#03f9cb8a81c3e5ab2c51684557d5aaf6d2569759"
+  integrity sha512-HYPSb7y/Z7BNDCOrakL4raGO2zltZkbeXyAd6Tg9obzix6QhzxCotdBl6VT0Dv4vZfJGVz3WL/xaEI9Ly3ul0g==
+
 css-selector-parser@^1.1.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/css-selector-parser/-/css-selector-parser-1.3.0.tgz#5f1ad43e2d8eefbfdc304fcd39a521664943e3eb"
@@ -12634,6 +12639,11 @@ normalize.css@^8.0.1:
   resolved "https://registry.yarnpkg.com/normalize.css/-/normalize.css-8.0.1.tgz#9b98a208738b9cc2634caacbc42d131c97487bf3"
   integrity sha512-qizSNPO93t1YUuUhP22btGOo3chcvDFqFaj2TRybP0DMxkHOCTYwp3n34fel4a31ORXy4m1Xq0Gyqpb5m33qIg==
 
+not@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/not/-/not-0.1.0.tgz#c9691c1746c55dcfbe54cbd8bd4ff041bc2b519d"
+  integrity sha1-yWkcF0bFXc++VMvYvU/wQbwrUZ0=
+
 npm-conf@^1.1.0:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/npm-conf/-/npm-conf-1.1.3.tgz#256cc47bd0e218c259c4e9550bf413bc2192aff9"
@@ -12666,7 +12676,7 @@ npmlog@^4.0.1, npmlog@^4.1.2:
     gauge "~2.7.3"
     set-blocking "~2.0.0"
 
-nth-check@^1.0.1, nth-check@^1.0.2, nth-check@~1.0.1:
+nth-check@^1.0.0, nth-check@^1.0.1, nth-check@^1.0.2, nth-check@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-1.0.2.tgz#b2bd295c37e3dd58a3bf0700376663ba4d9cf05c"
   integrity sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==
@@ -17745,7 +17755,7 @@ unique-string@^2.0.0:
   dependencies:
     crypto-random-string "^2.0.0"
 
-unist-builder@2.0.3, unist-builder@^2.0.0:
+unist-builder@2.0.3, unist-builder@^2.0.0, unist-builder@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/unist-builder/-/unist-builder-2.0.3.tgz#77648711b5d86af0942f334397a33c5e91516436"
   integrity sha512-f98yt5pnlMWlzP539tPc4grGMsFaQQlP/vM396b00jngsiINumNmsY8rkXjfoi1c6QaM8nQ3vaGDuoKWbe/1Uw==
@@ -17835,6 +17845,17 @@ unist-util-select@^1.5.0:
     debug "^2.2.0"
     nth-check "^1.0.1"
 
+unist-util-select@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/unist-util-select/-/unist-util-select-3.0.1.tgz#787fc452db9ba77f0ade0e7dc53c3d9d4acc79c7"
+  integrity sha512-VQpTuqZVJlRbosQdnLdTPIIqwZeU70YZ5aMBOqtFNGeeCdYn6ORZt/9RiaVlbl06ocuf58SVMoFa7a13CSGPMA==
+  dependencies:
+    css-selector-parser "^1.0.0"
+    not "^0.1.0"
+    nth-check "^1.0.0"
+    unist-util-is "^4.0.0"
+    zwitch "^1.0.0"
+
 unist-util-stringify-position@^1.0.0, unist-util-stringify-position@^1.1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/unist-util-stringify-position/-/unist-util-stringify-position-1.1.2.tgz#3f37fcf351279dcbca7480ab5889bb8a832ee1c6"
@@ -17867,7 +17888,7 @@ unist-util-visit-parents@^3.0.0:
     "@types/unist" "^2.0.0"
     unist-util-is "^4.0.0"
 
-unist-util-visit@2.0.3:
+unist-util-visit@2.0.3, unist-util-visit@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/unist-util-visit/-/unist-util-visit-2.0.3.tgz#c3703893146df47203bb8a9795af47d7b971208c"
   integrity sha512-iJ4/RczbJMkD0712mGktuGpm/U4By4FfDonL7N/9tATGIF4imikjOuagyMY53tnZq3NP6BcmlrHhEKAfGWjh7Q==


### PR DESCRIPTION
Moves `twemoji.parse()` to AST phase in remark since the current implementation has caused differences in the rendering results between SSR and CSR.