### PR TITLE
Revert "Bump gatsby-plugin-sass from 2.3.22 to 2.4.2"

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "gatsby-plugin-no-sourcemaps": "^2.2.1",
     "gatsby-plugin-react-helmet": "^3.3.14",
     "gatsby-plugin-react-svg": "^3.0.0",
-    "gatsby-plugin-sass": "^2.4.2",
+    "gatsby-plugin-sass": "^2.3.22",
     "gatsby-plugin-sharp": "chitoku-k/gatsby-plugin-sharp#566121f",
     "gatsby-plugin-ts": "^2.7.1",
     "gatsby-remark-attr": "^0.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8089,10 +8089,10 @@ gatsby-plugin-react-svg@^3.0.0:
   dependencies:
     svg-react-loader "^0.4.4"
 
-gatsby-plugin-sass@^2.4.2:
-  version "2.4.2"
-  resolved "https://registry.yarnpkg.com/gatsby-plugin-sass/-/gatsby-plugin-sass-2.4.2.tgz#d5bdfc69b56c1f6b19eaf085c068607fc123e752"
-  integrity sha512-6DnB+sRoSTS/dpsk/r2rTEA40XanDhmHvk4Esv+flgS6zcZro4U6cc5ibR6tum/fdfdu8/T/RoPZgGLCm4e4sQ==
+gatsby-plugin-sass@^2.3.22:
+  version "2.3.22"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-sass/-/gatsby-plugin-sass-2.3.22.tgz#51839f971da763281d44d438933e0945c6e4d9b1"
+  integrity sha512-T+MYz5I859f7Fh1eO2X3h3bKaCN48TPHTqPyN9+vp6wc6yd3jNWx0YGlkDxo3ZxAS+7Fw7wThCp+J4WWQR7RVQ==
   dependencies:
     "@babel/runtime" "^7.11.2"
     sass-loader "^7.3.1"


### PR DESCRIPTION
Reverts chitoku-k/chitoku.jp#1984 because it broke the build entirely.