### PR TITLE
Disable babel compact option

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,5 @@
 {
+  "compact": false,
   "presets": [
     ["gatsby", {
       "reactRuntime": "automatic",


### PR DESCRIPTION
It caused the following warning:
```
[BABEL] Note: The code generator has deoptimised the styling of ...
```