### PR TITLE
Configure job timeout on GitHub Actions

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -45,6 +45,7 @@ jobs:
           restore-keys: public-
       - name: Build (dependencies)
         uses: docker/build-push-action@v2
+        timeout-minutes: 20
         with:
           context: .
           target: dependencies
@@ -52,6 +53,7 @@ jobs:
           cache-to: type=local,mode=max,dest=/tmp/buildx-cache.new
       - name: Build (cache)
         uses: docker/build-push-action@v2
+        timeout-minutes: 20
         with:
           context: .
           target: cache
@@ -61,6 +63,7 @@ jobs:
             GATSBY_UPDATE_INDEX=true
       - name: Build and push
         uses: docker/build-push-action@v2
+        timeout-minutes: 20
         with:
           context: .
           push: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
           restore-keys: public-
       - name: Build (dependencies)
         uses: docker/build-push-action@v2
+        timeout-minutes: 20
         with:
           context: .
           target: dependencies
@@ -42,6 +43,7 @@ jobs:
           cache-to: type=local,mode=max,dest=/tmp/buildx-cache.new
       - name: Build (cache)
         uses: docker/build-push-action@v2
+        timeout-minutes: 20
         with:
           context: .
           target: cache
@@ -49,6 +51,7 @@ jobs:
           outputs: type=local,dest=/tmp/buildx-result
       - name: Build
         uses: docker/build-push-action@v2
+        timeout-minutes: 20
         with:
           context: .
       - name: Move cache


### PR DESCRIPTION
Our builds very often stuck at some point in Docker build phases and it's consuming unnecessary resources. Here it bails them out.