### PR TITLE
Enforce TZ=Asia/Tokyo in SSR

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ RUN --mount=type=cache,target=/mnt/yarn,id=/usr/local/share/.cache/yarn \
     cp -r /mnt/yarn /usr/local/share/.cache/
 
 FROM dependencies AS build
+ARG TZ=Asia/Tokyo
 ARG GATSBY_UPDATE_INDEX=false
 COPY . /usr/src
 RUN --mount=type=tmpfs,target=/tmp \


### PR DESCRIPTION
Sets `Asia/Tokyo` in SSR builds as with UTC it has caused `Text content does not match server-rendered HTML` error. For non-`Asia/Tokyo` environments, ... 🙄