### PR TITLE
Export useArticle()/useSearch() hooks instead of Context instances

### DIFF
--- a/src/components/Article/index.tsx
+++ b/src/components/Article/index.tsx
@@ -1,5 +1,5 @@
 import type { FunctionComponent, ReactNode } from 'react'
-import { createContext } from 'react'
+import { createContext, useContext } from 'react'
 import { Nav, Navbar } from 'react-bootstrap'
 import { useIntl } from 'react-intl'
 
@@ -16,7 +16,7 @@ import { PaginationContainer, SimplePagination } from 'components/Pagination'
 
 export const getClassNameFromPath = (path: string): string => `page${path.replace(/[/]/ug, '-').replace(/-$/u, '')}`
 
-export const ArticleContext = createContext<ArticleItem>({
+const ArticleContext = createContext<ArticleItem>({
   path: '',
   attributes: {
     title: '',
@@ -30,6 +30,8 @@ export const ArticleContext = createContext<ArticleItem>({
   },
   excerpted: false,
 })
+
+export const useArticle = (): ArticleItem => useContext(ArticleContext)
 
 const Article: FunctionComponent<ArticleProps> = ({
   children,

--- a/src/components/Container/index.tsx
+++ b/src/components/Container/index.tsx
@@ -1,5 +1,5 @@
 import type { FunctionComponent, ReactNode } from 'react'
-import { memo, useContext } from 'react'
+import { memo } from 'react'
 import { Container as BootstrapContainer, Col, Row } from 'react-bootstrap'
 import { useLocation } from '@gatsbyjs/reach-router'
 import clsx from 'clsx'
@@ -7,7 +7,7 @@ import clsx from 'clsx'
 import * as styles from './styles.module.scss'
 
 import Sidebar from 'components/Sidebar'
-import { SearchContext } from 'components/Search'
+import { useSearch } from 'components/Search'
 import SearchResult from 'components/SearchResult'
 
 const MemoizedSidebar = memo(Sidebar, (prev, next) => prev.location.pathname === next.location.pathname)
@@ -18,7 +18,7 @@ const Container: FunctionComponent<ContainerProps> = ({
   sidebar,
 }) => {
   const location = useLocation()
-  const { query } = useContext(SearchContext)
+  const { query } = useSearch()
 
   return (
     <BootstrapContainer className={styles.container}>

--- a/src/components/PspSdkFunction/index.tsx
+++ b/src/components/PspSdkFunction/index.tsx
@@ -1,12 +1,11 @@
 import type { FunctionComponent, ReactNode } from 'react'
-import { useContext } from 'react'
 import clsx from 'clsx'
 import Prism from 'prismjs'
 import 'prismjs/components/prism-c'
 
 import * as styles from './styles.module.scss'
 
-import { ArticleContext } from 'components/Article'
+import { useArticle } from 'components/Article'
 
 const indentationWidth = 4
 const linebreakThreshold = 2
@@ -20,7 +19,7 @@ const PspSdkFunction: FunctionComponent<PspSdkFunctionProps> = ({
   children,
   name: functionName,
 }) => {
-  const article = useContext(ArticleContext)
+  const article = useArticle()
   const def = article.attributes.functions?.find(x => x.name === functionName)
   if (!def) {
     return null

--- a/src/components/PspSdkMacro/index.tsx
+++ b/src/components/PspSdkMacro/index.tsx
@@ -1,12 +1,11 @@
 import type { FunctionComponent, ReactNode } from 'react'
-import { useContext } from 'react'
 import clsx from 'clsx'
 import Prism from 'prismjs'
 import 'prismjs/components/prism-c'
 
 import * as styles from './styles.module.scss'
 
-import { ArticleContext } from 'components/Article'
+import { useArticle } from 'components/Article'
 
 const indentationWidth = 4
 const linebreakThreshold = 2
@@ -18,7 +17,7 @@ const PspSdkMacro: FunctionComponent<PspSdkMacroProps> = ({
   children,
   name: macroName,
 }) => {
-  const article = useContext(ArticleContext)
+  const article = useArticle()
   const def = article.attributes.macros?.find(x => x.name === macroName)
   if (!def) {
     return null

--- a/src/components/Search/index.tsx
+++ b/src/components/Search/index.tsx
@@ -1,15 +1,17 @@
 import type { FunctionComponent, ReactNode } from 'react'
-import { useMemo } from 'react'
+import { useContext, useMemo } from 'react'
 import { createContext, useState } from 'react'
 import { InstantSearch } from 'react-instantsearch-dom'
 import algoliasearch from 'algoliasearch'
 
-export const SearchContext = createContext<SearchState>({
+const SearchContext = createContext<SearchState>({
   query: null,
   setQuery: () => {
     throw new Error('setQuery is not provided')
   },
 })
+
+export const useSearch = (): SearchState => useContext(SearchContext)
 
 const Search: FunctionComponent<SearchProps> = ({
   children,

--- a/src/components/SearchForm/index.tsx
+++ b/src/components/SearchForm/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useContext, useEffect, useRef } from 'react'
+import { useCallback, useEffect, useRef } from 'react'
 import { Container, Nav, Popover, Row } from 'react-bootstrap'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faSearch } from '@fortawesome/free-solid-svg-icons'
@@ -6,7 +6,7 @@ import { useIntl } from 'react-intl'
 import type { SearchBoxProvided } from 'react-instantsearch-core'
 import { connectSearchBox } from 'react-instantsearch-dom'
 
-import { SearchContext } from 'components/Search'
+import { useSearch } from 'components/Search'
 
 import messages from './messages'
 import * as styles from './styles.module.scss'
@@ -18,7 +18,7 @@ const SearchForm = connectSearchBox<SearchFormProps>(function SearchForm({
 }) {
   const { formatMessage } = useIntl()
 
-  const { query, setQuery } = useContext(SearchContext)
+  const { query, setQuery } = useSearch()
   const input = useRef<HTMLInputElement>(null)
 
   const onSubmit = useCallback((e: React.FormEvent<HTMLFormElement>) => {

--- a/src/components/SearchResult/index.tsx
+++ b/src/components/SearchResult/index.tsx
@@ -1,5 +1,5 @@
 import type { FunctionComponent, MouseEvent } from 'react'
-import { useCallback, useContext } from 'react'
+import { useCallback } from 'react'
 import { FormattedMessage, useIntl } from 'react-intl'
 import type { Hit, StateResultsProvided } from 'react-instantsearch-core'
 import { Hits, PoweredBy, connectStateResults } from 'react-instantsearch-dom'
@@ -13,7 +13,7 @@ import ArticleContainer from 'components/ArticleContainer'
 import ArticleHeader from 'components/ArticleHeader'
 import type { ArticleCategoryItem, ArticleTagItem } from 'components/Article'
 import Link from 'components/Link'
-import { SearchContext } from 'components/Search'
+import { useSearch } from 'components/Search'
 
 const SearchHit: FunctionComponent<SearchHitProps<SearchDocument>> = ({
   hit: {
@@ -25,7 +25,7 @@ const SearchHit: FunctionComponent<SearchHitProps<SearchDocument>> = ({
   },
 }) => {
   const { formatMessage } = useIntl()
-  const { setQuery } = useContext(SearchContext)
+  const { setQuery } = useSearch()
   const handleClick = useCallback((e: MouseEvent<HTMLAnchorElement>) => {
     e.preventDefault()
 


### PR DESCRIPTION
This ensures that provider is not exported and the correct usage is guaranteed.