### PR TITLE
Unwrap custom components from remark in historia-remark-plugin

### DIFF
--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -112,7 +112,6 @@ const config: GatsbyConfig = {
               offsetY: 10,
             },
           },
-          { resolve: '@rstacruz/gatsby-remark-component' },
           { resolve: 'gatsby-remark-copy-linked-files' },
           { resolve: 'gatsby-remark-embed-gist' },
           {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "@fortawesome/free-solid-svg-icons": "^6.2.1",
     "@fortawesome/react-fontawesome": "^0.2.0",
     "@gatsbyjs/reach-router": "^2.0.0",
-    "@rstacruz/gatsby-remark-component": "^2.0.0",
     "@storybook/addon-actions": "^6.5.15",
     "@storybook/addon-essentials": "^6.5.15",
     "@storybook/addon-links": "^6.5.15",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3075,11 +3075,6 @@
     uncontrollable "^7.2.1"
     warning "^4.0.3"
 
-"@rstacruz/gatsby-remark-component@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@rstacruz/gatsby-remark-component/-/gatsby-remark-component-2.0.0.tgz#ecc81499c43729379b7ea80b909ef120c9afa7dd"
-  integrity sha512-R6HyaD/k5tC+ffpx4j6CyXWkp2fk59zAlEaeXIgvTZ2bARNcXcBwOZ2kA4kAHtVRQgtA982r/xIdAIIBAD+yDQ==
-
 "@selderee/plugin-htmlparser2@^0.10.0":
   version "0.10.0"
   resolved "https://registry.yarnpkg.com/@selderee/plugin-htmlparser2/-/plugin-htmlparser2-0.10.0.tgz#8a304d18df907e086f3cfc71ea0ced52d6524430"


### PR DESCRIPTION
This PR removes `gatsby-remark-component` which replaces the root node with a `div` element whereas the implementation in this PR does not break the root element.