### PR TITLE
Install gatsby-remark-remove-cjk-breaks

### DIFF
--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -143,6 +143,7 @@ const config: GatsbyConfig = {
               ],
             },
           },
+          { resolve: 'gatsby-remark-remove-cjk-breaks' },
           { resolve: 'historia-remark-plugin' },
         ],
       },

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "gatsby-remark-grid-tables": "^0.1.0",
     "gatsby-remark-images": "^7.4.0",
     "gatsby-remark-prismjs": "^7.4.0",
+    "gatsby-remark-remove-cjk-breaks": "^1.2.1",
     "gatsby-source-filesystem": "^5.4.0",
     "gatsby-source-local-git": "^1.3.0",
     "gatsby-transformer-remark": "^6.4.0",

--- a/plugins/historia-remark-plugin/index.ts
+++ b/plugins/historia-remark-plugin/index.ts
@@ -1,10 +1,6 @@
 import type { Node } from 'unist'
 import * as visit from 'unist-util-visit'
 import * as twemoji from 'twemoji'
-import * as unicode from 'unicode-properties'
-
-// eslint-disable-next-line no-control-regex
-const WHITE_SPACE_TRANSFORM_PATTERN = /(?<before>[^\x01-\x7E])\s*\n+\s*(?<after>[^\x01-\x7E])/gu
 
 const CUSTOM_ELEMENT_HTML_PATTERN = /<\/?[a-z]+-/u
 
@@ -19,51 +15,6 @@ interface RemarkNode extends Node {
   children?: RemarkNode[]
   value?: string
 }
-
-/**
- * This function is equivalent implementation to IsEastAsianWidthFHWexcludingEmoji in Firefox.
- *
- * See: https://searchfox.org/mozilla-central/rev/ca22dc04/intl/unicharutil/util/nsUnicodeProperties.h#141-154
- */
-const isEastAsianWidthFHWexcludingEmoji = (ch: string): boolean => {
-  const codePoint = ch.codePointAt(0)
-  if (!codePoint) {
-    return false
-  }
-  switch (unicode.getEastAsianWidth(codePoint)) {
-    case 'F':
-    case 'H':
-      return true
-    case 'W':
-      // Here considers emoji fullwidth...
-      return true
-    case 'A':
-    case 'Na':
-    case 'N':
-    default:
-      return false
-  }
-}
-
-/**
- * This function is equivalent implementation to IsSegmentBreakSkipChar in Firefox.
- *
- * See: https://searchfox.org/mozilla-central/rev/ca22dc04/intl/unicharutil/util/nsUnicharUtils.cpp#516-519
- */
-const isSegmentBreakSkipChar = (ch: string): boolean => {
-  const codePoint = ch.codePointAt(0)
-  if (!codePoint) {
-    return false
-  }
-  return isEastAsianWidthFHWexcludingEmoji(ch) && unicode.getScript(codePoint) !== 'Hangul'
-}
-
-/**
- * This function does the same as TransformWhiteSpaces in Firefox.
- *
- * See: https://searchfox.org/mozilla-central/rev/ca22dc04/layout/generic/nsTextFrameUtils.cpp#115-118
- */
-const isSegmentBreakSkippable = (before: string, after: string): boolean => isSegmentBreakSkipChar(before) && isSegmentBreakSkipChar(after)
 
 export default ({
   markdownAST,
@@ -84,19 +35,6 @@ export default ({
     node.type = 'html'
     node.value = twemoji.parse(node.value, {
       base: 'https://cdn.jsdelivr.net/gh/twitter/twemoji@latest/assets/',
-    })
-  })
-
-  // Remove whitespaces between the fullwidth characters
-  visit<RemarkNode>(markdownAST, [ 'text' ], node => {
-    if (!node.value || !WHITE_SPACE_TRANSFORM_PATTERN.test(node.value)) {
-      return
-    }
-    node.value = node.value.replace(WHITE_SPACE_TRANSFORM_PATTERN, (match: string, before: string, after: string): string => {
-      if (!isSegmentBreakSkippable(before, after)) {
-        return match
-      }
-      return before + after
     })
   })
 }

--- a/plugins/historia-remark-plugin/package.json
+++ b/plugins/historia-remark-plugin/package.json
@@ -3,9 +3,7 @@
   "version": "1.0.0",
   "dependencies": {
     "@types/twemoji": "~12",
-    "@types/unicode-properties": "^1.3.0",
     "twemoji": "^14.0.2",
-    "unicode-properties": "^1.4.1",
     "unist-util-visit": "^2.0.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4746,11 +4746,6 @@
   dependencies:
     source-map "^0.6.1"
 
-"@types/unicode-properties@^1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@types/unicode-properties/-/unicode-properties-1.3.0.tgz#3413d065ce7cde96471b42b17a8442664535f42b"
-  integrity sha512-kDVlxpdkCfgvzfXcglkr7j4OSMjCEEo/Jloj4tFuldYZpQ9Uypy7FGXPhNstoj4eGvhddwuu5n0EfI+XdWVoVA==
-
 "@types/unist@*", "@types/unist@^2.0.0", "@types/unist@^2.0.2", "@types/unist@^2.0.3", "@types/unist@^2.0.6":
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.6.tgz#250a7b16c3b91f672a24552ec64678eeb1d3a08d"
@@ -6151,7 +6146,7 @@ base-x@^3.0.8:
   dependencies:
     safe-buffer "^5.0.1"
 
-base64-js@^1.0.2, base64-js@^1.3.0, base64-js@^1.3.1:
+base64-js@^1.0.2, base64-js@^1.3.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
@@ -10170,6 +10165,13 @@ gatsby-remark-prismjs@^7.4.0:
   dependencies:
     "@babel/runtime" "^7.20.7"
     parse-numeric-range "^1.2.0"
+    unist-util-visit "^2.0.3"
+
+gatsby-remark-remove-cjk-breaks@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/gatsby-remark-remove-cjk-breaks/-/gatsby-remark-remove-cjk-breaks-1.2.1.tgz#5803f98090199acdd75cf10c01c20983b9ddffb1"
+  integrity sha512-WO1Ayb/AvrqScfL5/krcGheXNShSR7oC3o4y+YcFUFzWd7H4XdpS7fWtdDUaRmwrUt8e/zVaL2+gAfRpLUuKjQ==
+  dependencies:
     unist-util-visit "^2.0.3"
 
 gatsby-script@^2.4.0:
@@ -14610,11 +14612,6 @@ package-json@^8.1.0:
     registry-url "^6.0.0"
     semver "^7.3.7"
 
-pako@^0.2.5:
-  version "0.2.9"
-  resolved "https://registry.yarnpkg.com/pako/-/pako-0.2.9.tgz#f3f7522f4ef782348da8161bad9ecfd51bf83a75"
-  integrity sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU=
-
 pako@~1.0.5:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.11.tgz#6c9599d340d54dfd3946380252a35705a6b992bf"
@@ -18460,11 +18457,6 @@ timsort@^0.3.0:
   resolved "https://registry.yarnpkg.com/timsort/-/timsort-0.3.0.tgz#405411a8e7e6339fe64db9a234de11dc31e02bd4"
   integrity sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=
 
-tiny-inflate@^1.0.0:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/tiny-inflate/-/tiny-inflate-1.0.3.tgz#122715494913a1805166aaf7c93467933eea26c4"
-  integrity sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==
-
 title-case@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/title-case/-/title-case-3.0.3.tgz#bc689b46f02e411f1d1e1d081f7c3deca0489982"
@@ -18888,26 +18880,10 @@ unicode-match-property-value-ecmascript@^2.0.0:
   resolved "https://registry.yarnpkg.com/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-2.0.0.tgz#1a01aa57247c14c568b89775a54938788189a714"
   integrity sha512-7Yhkc0Ye+t4PNYzOGKedDhXbYIBe1XEQYQxOPyhcXNMJ0WCABqqj6ckydd6pWRZTHV4GuCPKdBAUiMc60tsKVw==
 
-unicode-properties@^1.4.1:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/unicode-properties/-/unicode-properties-1.4.1.tgz#96a9cffb7e619a0dc7368c28da27e05fc8f9be5f"
-  integrity sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==
-  dependencies:
-    base64-js "^1.3.0"
-    unicode-trie "^2.0.0"
-
 unicode-property-aliases-ecmascript@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.0.0.tgz#0a36cb9a585c4f6abd51ad1deddb285c165297c8"
   integrity sha512-5Zfuy9q/DFr4tfO7ZPeVXb1aPoeQSdeFMLpYuFebehDAhbuevLs5yxSZmIFN1tP5F9Wl4IpJrYojg85/zgyZHQ==
-
-unicode-trie@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/unicode-trie/-/unicode-trie-2.0.0.tgz#8fd8845696e2e14a8b67d78fa9e0dd2cad62fec8"
-  integrity sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==
-  dependencies:
-    pako "^0.2.5"
-    tiny-inflate "^1.0.0"
 
 unified@9.2.0:
   version "9.2.0"


### PR DESCRIPTION
Removing whitespaces between the fullwidth characters are now performed by `gatsby-remark-remove-cjk-breaks`!