### PR TITLE
Configure grouped version updates for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,37 @@ updates:
     day: saturday
     time: "00:00"
     timezone: Asia/Tokyo
+  groups:
+    fontawesome:
+      patterns:
+      - "@fortawesome/*-core"
+      - "@fortawesome/*-icons"
+    gatsby:
+      patterns:
+      - gatsby
+      - gatsby-plugin-google-etag
+      - gatsby-plugin-no-sourcemaps
+      - gatsby-plugin-react-helmet
+      - gatsby-plugin-sass
+      - gatsby-remark-autolink-headers
+      - gatsby-remark-copy-linked-files
+      - gatsby-remark-images
+      - gatsby-remark-prismjs
+      - gatsby-source-filesystem
+      - gatsby-transformer-remark
+      - gatsby-transformer-sharp
+      - gatsby-transformer-yaml
+    react:
+      patterns:
+      - react
+      - react-dom
+    storybook:
+      patterns:
+      - "@storybook/addon-*"
+      - "@storybook/react-*"
+    typescript-eslint:
+      patterns:
+      - "@typescript-eslint/*"
   open-pull-requests-limit: 99
   versioning-strategy: increase
 - package-ecosystem: docker


### PR DESCRIPTION
https://github.blog/changelog/2023-06-30-grouped-version-updates-for-dependabot-public-beta/