### PR TITLE
Remove source-map from resolutions

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,8 +102,7 @@
   },
   "resolutions": {
     "remark": "^12",
-    "remark-footnotes": "^2",
-    "source-map": "^0"
+    "remark-footnotes": "^2"
   },
   "scripts": {
     "postinstall": "husky install",

--- a/yarn.lock
+++ b/yarn.lock
@@ -24484,7 +24484,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"source-map@npm:^0":
+"source-map@npm:0.5.6":
+  version: 0.5.6
+  resolution: "source-map@npm:0.5.6"
+  checksum: c62fe98e106c762307eea3a982242c1a76a31bc762da10fe2dda12252d423c163e0cd45d313330c8bd040cc5121702511138252308f72b8a9273825e81e4db30
+  languageName: node
+  linkType: hard
+
+"source-map@npm:0.6.1, source-map@npm:^0.6.0, source-map@npm:^0.6.1, source-map@npm:~0.6.0, source-map@npm:~0.6.1":
+  version: 0.6.1
+  resolution: "source-map@npm:0.6.1"
+  checksum: 59ef7462f1c29d502b3057e822cdbdae0b0e565302c4dd1a95e11e793d8d9d62006cdc10e0fd99163ca33ff2071360cf50ee13f90440806e7ed57d81cba2f7ff
+  languageName: node
+  linkType: hard
+
+"source-map@npm:^0.7.3, source-map@npm:~0.7.2":
   version: 0.7.4
   resolution: "source-map@npm:0.7.4"
   checksum: a0f7c9b797eda93139842fd28648e868a9a03ea0ad0d9fa6602a0c1f17b7fb6a7dcca00c144476cccaeaae5042e99a285723b1a201e844ad67221bf5d428f1dc


### PR DESCRIPTION
source-map was fixed at ^0 since b5eed674bc1e8362e8c7dc0fc5a5bcf0a7e7bda8 but it is no longer needed.

The affected version is >= 0.7.0 and < 0.7.4.