### PR TITLE
Replace deprecated `Story` with `StoryFn` in stories

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@types/hast": "^3.0.3",
     "@types/node": "^20.10.6",
     "@types/prismjs": "^1.26.3",
-    "@types/react": "^18.2.46",
+    "@types/react": "^18.2.47",
     "@types/react-dom": "^18.2.18",
     "@types/react-helmet": "^6.1.11",
     "@typescript-eslint/eslint-plugin": "^6.17.0",

--- a/src/components/ArticleAttribute/index.stories.tsx
+++ b/src/components/ArticleAttribute/index.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { IntlProvider } from 'react-intl'
 import { LocationProvider, createHistory, createMemorySource } from '@gatsbyjs/reach-router'
-import type { Meta, Story } from '@storybook/react'
+import type { Meta, StoryFn } from '@storybook/react'
 
 import messages from 'translations/ja.yml'
 import type { ArticleAttributeProps } from 'components/ArticleAttribute'
@@ -19,7 +19,7 @@ const meta: Meta = {
 
 const history = createHistory(createMemorySource('/'))
 
-const Template: Story<ArticleAttributeProps> = props => (
+const Template: StoryFn<ArticleAttributeProps> = props => (
   <IntlProvider locale="ja" messages={messages}>
     <LocationProvider history={history}>
       <ArticleAttribute {...props} />

--- a/src/components/ArticleBody/index.stories.tsx
+++ b/src/components/ArticleBody/index.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { LocationProvider, createHistory, createMemorySource } from '@gatsbyjs/reach-router'
-import type { Meta, Story } from '@storybook/react'
+import type { Meta, StoryFn } from '@storybook/react'
 
 import type { ArticleBodyProps } from 'components/ArticleBody'
 import ArticleBody, { register } from 'components/ArticleBody'
@@ -20,7 +20,7 @@ const meta: Meta = {
 
 const history = createHistory(createMemorySource('/'))
 
-const Template: Story<ArticleBodyProps> = props => (
+const Template: StoryFn<ArticleBodyProps> = props => (
   <LocationProvider history={history}>
     <ArticleBody {...props} />
   </LocationProvider>

--- a/src/components/ArticleHeader/index.stories.tsx
+++ b/src/components/ArticleHeader/index.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import type { Meta, Story } from '@storybook/react'
+import type { Meta, StoryFn } from '@storybook/react'
 
 import type { ArticleHeaderProps } from 'components/ArticleHeader'
 import ArticleHeader from 'components/ArticleHeader'
@@ -14,7 +14,7 @@ const meta: Meta = {
   },
 }
 
-const Template: Story<ArticleHeaderProps> = props => (
+const Template: StoryFn<ArticleHeaderProps> = props => (
   <ArticleHeader {...props} />
 )
 

--- a/src/components/CategoryIcon/index.stories.tsx
+++ b/src/components/CategoryIcon/index.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { LocationProvider, createHistory, createMemorySource } from '@gatsbyjs/reach-router'
-import type { Meta, Story } from '@storybook/react'
+import type { Meta, StoryFn } from '@storybook/react'
 
 import type { CategoryIconProps } from 'components/CategoryIcon'
 import CategoryIcon from 'components/CategoryIcon'
@@ -24,7 +24,7 @@ const meta: Meta = {
 
 const history = createHistory(createMemorySource('/'))
 
-const Template: Story<CategoryIconProps> = props => (
+const Template: StoryFn<CategoryIconProps> = props => (
   <LocationProvider history={history}>
     <CategoryIcon {...props} />
   </LocationProvider>

--- a/src/components/Pagination/index.stories.tsx
+++ b/src/components/Pagination/index.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { IntlProvider } from 'react-intl'
 import { LocationProvider, createHistory, createMemorySource } from '@gatsbyjs/reach-router'
-import type { Meta, Story } from '@storybook/react'
+import type { Meta, StoryFn } from '@storybook/react'
 
 import messages from 'translations/ja.yml'
 import type { PaginationProps } from 'components/Pagination'
@@ -19,7 +19,7 @@ const meta: Meta = {
 
 const history = createHistory(createMemorySource('/'))
 
-const Template: Story<PaginationProps> = props => (
+const Template: StoryFn<PaginationProps> = props => (
   <IntlProvider locale="ja" messages={messages}>
     <LocationProvider history={history}>
       <Pagination {...props} />

--- a/src/components/Pagination/simple.stories.tsx
+++ b/src/components/Pagination/simple.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { IntlProvider } from 'react-intl'
 import { LocationProvider, createHistory, createMemorySource } from '@gatsbyjs/reach-router'
-import type { Meta, Story } from '@storybook/react'
+import type { Meta, StoryFn } from '@storybook/react'
 
 import messages from 'translations/ja.yml'
 import type { SimplePaginationProps } from 'components/Pagination'
@@ -19,7 +19,7 @@ const meta: Meta = {
 
 const history = createHistory(createMemorySource('/'))
 
-const Template: Story<SimplePaginationProps> = props => (
+const Template: StoryFn<SimplePaginationProps> = props => (
   <IntlProvider locale="ja" messages={messages}>
     <LocationProvider history={history}>
       <SimplePagination {...props} />

--- a/src/components/Sidebar/index.stories.tsx
+++ b/src/components/Sidebar/index.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { IntlProvider } from 'react-intl'
 import { LocationProvider, createHistory, createMemorySource } from '@gatsbyjs/reach-router'
-import type { Meta, Story } from '@storybook/react'
+import type { Meta, StoryFn } from '@storybook/react'
 
 import messages from 'translations/ja.yml'
 import type { SidebarProps } from 'components/Sidebar'
@@ -14,7 +14,7 @@ const meta: Meta = {
 
 const history = createHistory(createMemorySource('/'))
 
-const Template: Story<SidebarProps> = props => (
+const Template: StoryFn<SidebarProps> = props => (
   <IntlProvider locale="ja" messages={messages}>
     <LocationProvider history={history}>
       <Sidebar {...props} />

--- a/src/components/TwitterTweet/index.stories.tsx
+++ b/src/components/TwitterTweet/index.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { LocationProvider, createHistory, createMemorySource } from '@gatsbyjs/reach-router'
-import type { Meta, Story } from '@storybook/react'
+import type { Meta, StoryFn } from '@storybook/react'
 
 import type { TwitterTweetProps } from 'components/TwitterTweet'
 import TwitterTweet from 'components/TwitterTweet'
@@ -17,7 +17,7 @@ const meta: Meta = {
 
 const history = createHistory(createMemorySource('/'))
 
-const Template: Story<TwitterTweetProps> = props => (
+const Template: StoryFn<TwitterTweetProps> = props => (
   <LocationProvider history={history}>
     <TwitterTweet {...props} />
   </LocationProvider>

--- a/yarn.lock
+++ b/yarn.lock
@@ -8521,25 +8521,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react@npm:*, @types/react@npm:16 || 17 || 18, @types/react@npm:>=16, @types/react@npm:>=16.9.11":
-  version: 18.2.5
-  resolution: "@types/react@npm:18.2.5"
+"@types/react@npm:*, @types/react@npm:16 || 17 || 18, @types/react@npm:>=16, @types/react@npm:>=16.9.11, @types/react@npm:^18.2.47":
+  version: 18.2.47
+  resolution: "@types/react@npm:18.2.47"
   dependencies:
     "@types/prop-types": "npm:*"
     "@types/scheduler": "npm:*"
     csstype: "npm:^3.0.2"
-  checksum: dda71de3b6185ac1294bb83aed1ff542dbb7d842df662a377f6fc06e4fcb72df4b3847c72e28ab75027a3d7b26660685c73eaf032fbe32d7c639b233d53aa5a2
-  languageName: node
-  linkType: hard
-
-"@types/react@npm:^18.2.46":
-  version: 18.2.46
-  resolution: "@types/react@npm:18.2.46"
-  dependencies:
-    "@types/prop-types": "npm:*"
-    "@types/scheduler": "npm:*"
-    csstype: "npm:^3.0.2"
-  checksum: 10fb28a5b8504106512ce3b154c45d1ac045c31633786773a29f003b3079b434060368bb56f95ef6c39510835ceec4fb8fdc271d6ca2b9cdd979379cf53f126b
+  checksum: 0a98c2ef8303909f78c973ac9731cb671f3a0b96bc5213b538d1a50cbaae6e51b6befd64845a9cb95af8528767315d5bd99a85608eb716c020393c7d33a9b477
   languageName: node
   linkType: hard
 
@@ -16510,7 +16499,7 @@ __metadata:
     "@types/hast": "npm:^3.0.3"
     "@types/node": "npm:^20.10.6"
     "@types/prismjs": "npm:^1.26.3"
-    "@types/react": "npm:^18.2.46"
+    "@types/react": "npm:^18.2.47"
     "@types/react-dom": "npm:^18.2.18"
     "@types/react-helmet": "npm:^6.1.11"
     "@typescript-eslint/eslint-plugin": "npm:^6.17.0"


### PR DESCRIPTION
`Story` has been deprecated since `@storybook/react` v7.0.0.