### PR TITLE
Update the gatsby group of Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,8 +21,9 @@ updates:
       - "@fortawesome/*-icons"
     gatsby:
       patterns:
+      - babel-preset-gatsby
       - gatsby
-      - gatsby-plugin-google-etag
+      - gatsby-plugin-google-gtag
       - gatsby-plugin-no-sourcemaps
       - gatsby-plugin-sass
       - gatsby-remark-autolink-headers


### PR DESCRIPTION
Fixes monorepo patterns in `.github/dependabot.yml`.