### PR TITLE
Move the CSS declarations above the nested rules

### DIFF
--- a/src/components/ArticleCard/styles.module.scss
+++ b/src/components/ArticleCard/styles.module.scss
@@ -22,14 +22,14 @@
 }
 
 .link {
+  padding: 0;
+  font-size: 120%;
+  font-weight: bold;
+
   &,
   &:hover {
     color: var(--containers-color);
   }
-
-  padding: 0;
-  font-size: 120%;
-  font-weight: bold;
 
   @include media-breakpoint-down(lg) {
     font-size: 100%;

--- a/src/components/Home/styles.module.scss
+++ b/src/components/Home/styles.module.scss
@@ -83,14 +83,14 @@
 }
 
 .link {
+  font-size: 120%;
+  font-weight: bold;
+  white-space: nowrap;
+
   &,
   &:hover {
     color: var(--containers-color);
   }
-
-  font-size: 120%;
-  font-weight: bold;
-  white-space: nowrap;
 
   @include media-breakpoint-down(md) {
     display: block;

--- a/src/components/Mail/styles.module.scss
+++ b/src/components/Mail/styles.module.scss
@@ -31,14 +31,14 @@
 }
 
 .input {
+  font-size: 16px;
+  resize: vertical;
+
   &,
   &:focus {
     color: var(--containers-color);
     background-color: var(--containers-background);
   }
-
-  font-size: 16px;
-  resize: vertical;
 }
 
 .wrapper {

--- a/src/components/Navbar/styles.module.scss
+++ b/src/components/Navbar/styles.module.scss
@@ -46,11 +46,11 @@
   }
 
   @include media-breakpoint-down(md) {
+    width: 100%;
+
     &.search {
       display: none;
     }
-
-    width: 100%;
   }
 }
 


### PR DESCRIPTION
This PR fixes the following warnings:

```
DEPRECATION WARNING: Sass's behavior for declarations that appear after nested
rules will be changing to match the behavior specified by CSS in an upcoming
version. To keep the existing behavior, move the declaration above the nested
rule. To opt into the new behavior, wrap the declaration in `& {}`.

More info: https://sass-lang.com/d/mixed-decls

    ╷
34  │ ┌   &,
35  │ │   &:focus {
36  │ │     color: var(--containers-color);
37  │ │     background-color: var(--containers-background);
38  │ │   }
    │ └─── nested rule
... │
40  │     font-size: 16px;
    │     ^^^^^^^^^^^^^^^ declaration
    ╵
    src/components/Mail/styles.module.scss 40:3  root stylesheet
```

```
DEPRECATION WARNING: Sass's behavior for declarations that appear after nested
rules will be changing to match the behavior specified by CSS in an upcoming
version. To keep the existing behavior, move the declaration above the nested
rule. To opt into the new behavior, wrap the declaration in `& {}`.

More info: https://sass-lang.com/d/mixed-decls

    ╷
34  │ ┌   &,
35  │ │   &:focus {
36  │ │     color: var(--containers-color);
37  │ │     background-color: var(--containers-background);
38  │ │   }
    │ └─── nested rule
... │
41  │     resize: vertical;
    │     ^^^^^^^^^^^^^^^^ declaration
    ╵
    src/components/Mail/styles.module.scss 41:3  root stylesheet
```

```
DEPRECATION WARNING: Sass's behavior for declarations that appear after nested
rules will be changing to match the behavior specified by CSS in an upcoming
version. To keep the existing behavior, move the declaration above the nested
rule. To opt into the new behavior, wrap the declaration in `& {}`.

More info: https://sass-lang.com/d/mixed-decls

    ╷
49  │ ┌     &.search {
50  │ │       display: none;
51  │ │     }
    │ └─── nested rule
... │
53  │       width: 100%;
    │       ^^^^^^^^^^^ declaration
    ╵
    src/components/Navbar/styles.module.scss 53:5              @content
    node_modules/bootstrap/scss/mixins/_breakpoints.scss 78:7  media-breakpoint-down()
    src/components/Navbar/styles.module.scss 48:3              root stylesheet
```

```
DEPRECATION WARNING: Sass's behavior for declarations that appear after nested
rules will be changing to match the behavior specified by CSS in an upcoming
version. To keep the existing behavior, move the declaration above the nested
rule. To opt into the new behavior, wrap the declaration in `& {}`.

More info: https://sass-lang.com/d/mixed-decls

    ╷
86  │ ┌   &,
87  │ │   &:hover {
88  │ │     color: var(--containers-color);
89  │ │   }
    │ └─── nested rule
... │
91  │     font-size: 120%;
    │     ^^^^^^^^^^^^^^^ declaration
    ╵
    src/components/Home/styles.module.scss 91:3  root stylesheet
```

```
DEPRECATION WARNING: Sass's behavior for declarations that appear after nested
rules will be changing to match the behavior specified by CSS in an upcoming
version. To keep the existing behavior, move the declaration above the nested
rule. To opt into the new behavior, wrap the declaration in `& {}`.

More info: https://sass-lang.com/d/mixed-decls

    ╷
86  │ ┌   &,
87  │ │   &:hover {
88  │ │     color: var(--containers-color);
89  │ │   }
    │ └─── nested rule
... │
92  │     font-weight: bold;
    │     ^^^^^^^^^^^^^^^^^ declaration
    ╵
    src/components/Home/styles.module.scss 92:3  root stylesheet
```

```
DEPRECATION WARNING: Sass's behavior for declarations that appear after nested
rules will be changing to match the behavior specified by CSS in an upcoming
version. To keep the existing behavior, move the declaration above the nested
rule. To opt into the new behavior, wrap the declaration in `& {}`.

More info: https://sass-lang.com/d/mixed-decls

    ╷
86  │ ┌   &,
87  │ │   &:hover {
88  │ │     color: var(--containers-color);
89  │ │   }
    │ └─── nested rule
... │
93  │     white-space: nowrap;
    │     ^^^^^^^^^^^^^^^^^^^ declaration
    ╵
    src/components/Home/styles.module.scss 93:3  root stylesheet
```

```
DEPRECATION WARNING: Sass's behavior for declarations that appear after nested
rules will be changing to match the behavior specified by CSS in an upcoming
version. To keep the existing behavior, move the declaration above the nested
rule. To opt into the new behavior, wrap the declaration in `& {}`.

More info: https://sass-lang.com/d/mixed-decls

    ╷
25  │ ┌   &,
26  │ │   &:hover {
27  │ │     color: var(--containers-color);
28  │ │   }
    │ └─── nested rule
... │
30  │     padding: 0;
    │     ^^^^^^^^^^ declaration
    ╵
    src/components/ArticleCard/styles.module.scss 30:3  root stylesheet
```

```
DEPRECATION WARNING: Sass's behavior for declarations that appear after nested
rules will be changing to match the behavior specified by CSS in an upcoming
version. To keep the existing behavior, move the declaration above the nested
rule. To opt into the new behavior, wrap the declaration in `& {}`.

More info: https://sass-lang.com/d/mixed-decls

    ╷
25  │ ┌   &,
26  │ │   &:hover {
27  │ │     color: var(--containers-color);
28  │ │   }
    │ └─── nested rule
... │
31  │     font-size: 120%;
    │     ^^^^^^^^^^^^^^^ declaration
    ╵
    src/components/ArticleCard/styles.module.scss 31:3  root stylesheet
```

```
DEPRECATION WARNING: Sass's behavior for declarations that appear after nested
rules will be changing to match the behavior specified by CSS in an upcoming
version. To keep the existing behavior, move the declaration above the nested
rule. To opt into the new behavior, wrap the declaration in `& {}`.

More info: https://sass-lang.com/d/mixed-decls

    ╷
25  │ ┌   &,
26  │ │   &:hover {
27  │ │     color: var(--containers-color);
28  │ │   }
    │ └─── nested rule
... │
32  │     font-weight: bold;
    │     ^^^^^^^^^^^^^^^^^ declaration
    ╵
    src/components/ArticleCard/styles.module.scss 32:3  root stylesheet
```