### PR TITLE
Disable gtag when tracking ID is unset

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,3 @@
-GATSBY_GOOGLE_ANALYTICS_ID=UA-00000000-0
 GATSBY_REPOSITORY_NAME=chitoku-k/chitoku.jp
 GATSBY_REPOSITORY_TREE_URL=https://github.com/chitoku-k/chitoku.jp/tree/
 HISTORIA_URL=https://chitoku.jp

--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -41,9 +41,9 @@ const config: GatsbyConfig = {
     {
       resolve: 'gatsby-plugin-google-gtag',
       options: {
-        trackingIds: [
-          process.env.GATSBY_GOOGLE_ANALYTICS_ID,
-        ],
+        trackingIds: process.env.GATSBY_GOOGLE_ANALYTICS_ID
+          ? [ process.env.GATSBY_GOOGLE_ANALYTICS_ID ]
+          : [],
         gtagConfig: {
           cookie_flags: 'samesite=strict; secure',
         },


### PR DESCRIPTION
This would eliminate another dummy value that does not actually work.