### PR TITLE
Replace deprecated stylelint rule with its successor

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -16,7 +16,6 @@
     "scss/at-each-key-value-single-line": true,
     "scss/at-function-named-arguments": "never",
     "scss/at-function-parentheses-space-before": "never",
-    "scss/at-import-partial-extension": "never",
     "scss/at-mixin-argumentless-call-parentheses": "never",
     "scss/at-mixin-named-arguments": "never",
     "scss/at-mixin-parentheses-space-before": "never",
@@ -39,6 +38,7 @@
     "scss/double-slash-comment-whitespace-inside": "always",
     "scss/function-quote-no-quoted-strings-inside": true,
     "scss/function-unquote-no-unquoted-strings-inside": true,
+    "scss/load-partial-extension": "never",
     "scss/map-keys-quotes": "always",
     "scss/media-feature-value-dollar-variable": ["always", {
       "ignore": ["keywords"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -20063,28 +20063,28 @@ __metadata:
   linkType: hard
 
 "stylelint-config-recommended-scss@npm:^14.0.0":
-  version: 14.0.0
-  resolution: "stylelint-config-recommended-scss@npm:14.0.0"
+  version: 14.1.0
+  resolution: "stylelint-config-recommended-scss@npm:14.1.0"
   dependencies:
     postcss-scss: "npm:^4.0.9"
-    stylelint-config-recommended: "npm:^14.0.0"
-    stylelint-scss: "npm:^6.0.0"
+    stylelint-config-recommended: "npm:^14.0.1"
+    stylelint-scss: "npm:^6.4.0"
   peerDependencies:
     postcss: ^8.3.3
-    stylelint: ^16.0.2
+    stylelint: ^16.6.1
   peerDependenciesMeta:
     postcss:
       optional: true
-  checksum: 10/512fba4d81654b65a7a36d531f165c7d8f0c938e63a0f90daca0c21d623cc637e29195fec5e0ae1edd862502d69717f6f3e90016cd7ba8458e4a8afcd87bb3b4
+  checksum: 10/4dbebd9883e94eea9a6c7e1dc6978f385c4631e88a7014f41b14e2d8a5e52db6b4ac0015b41c75e8031e53c227a381b252a92ed48e6f2296c28d90fbb185f6eb
   languageName: node
   linkType: hard
 
-"stylelint-config-recommended@npm:^14.0.0":
-  version: 14.0.0
-  resolution: "stylelint-config-recommended@npm:14.0.0"
+"stylelint-config-recommended@npm:^14.0.0, stylelint-config-recommended@npm:^14.0.1":
+  version: 14.0.1
+  resolution: "stylelint-config-recommended@npm:14.0.1"
   peerDependencies:
-    stylelint: ^16.0.0
-  checksum: 10/36511115b06d9f51aa0edc05f6064a7aae98cc990da14dd03629951f63a029d9e66a4d5b1ca678cce699e24413a62c2cd608cc07413ca5026f9680ddb8993858
+    stylelint: ^16.1.0
+  checksum: 10/93c3fe920902abfd3f4130173876bb633230c910a3b293f5b74a0ea9c4427d197d7ade28dd62718246264f22f1e012899d0160a0176da723d14680d73876d701
   languageName: node
   linkType: hard
 
@@ -20127,7 +20127,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"stylelint-scss@npm:^6.0.0, stylelint-scss@npm:^6.5.0":
+"stylelint-scss@npm:^6.4.0, stylelint-scss@npm:^6.5.0":
   version: 6.5.0
   resolution: "stylelint-scss@npm:6.5.0"
   dependencies:


### PR DESCRIPTION
This PR replaces the deprecated stylelint rule (`scss/at-import-partial-extension`) with its successor (`scss/load-partial-extension`) and updates stylelint-config-recommended-scss to its latest version as it includes the same fix.