### PR TITLE
Fix `IPQoS` for OpenSSH 9.8p1 in /computers/edgerouter-x-flets-dscp

### DIFF
--- a/contents/posts/computers/edgerouter-x-flets-dscp.md
+++ b/contents/posts/computers/edgerouter-x-flets-dscp.md
@@ -14,7 +14,7 @@ tags:
 ```
 Host foo.example.com
     HostName  foo.example.com
-    IPQoS     0x00
+    IPQoS     0
 ```
 
 しかしながら、このような設定はルーター側で設定しておいたほうがクライアント側の設定が少なくて済むので楽です。


### PR DESCRIPTION
`parse_ipqos()` has been updated to use `strtonum(3bsd)` instead of `strtoul(3)` since OpenSSH 9.8p1:
https://github.com/openssh/openssh-portable/commit/ec78c31409590ad74efc194f886273ed080a545a