### PR TITLE
Publish `latest` images on push to master branch

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -42,7 +42,6 @@ jobs:
           cache-to: type=gha,mode=max
           push: true
           tags: |
-            ghcr.io/chitoku-k/chitoku.jp:latest
             ghcr.io/chitoku-k/chitoku.jp:${{ github.ref_name }}
           build-args: |
             CI

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,20 @@ jobs:
         uses: reviewdog/action-setup@v1
       - name: Set up .env
         run: cp .env{.example,}
+      - name: Extract .env
+        if: ${{ github.ref_name == 'master' }}
+        run: echo "$ENVFILE" > .env
+        env:
+          ENVFILE: ${{ secrets.ENVFILE }}
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+      - name: Log into Container Registry
+        if: ${{ github.ref_name == 'master' }}
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build
         uses: docker/build-push-action@v6
         id: build
@@ -33,6 +45,9 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           load: true
+          push: ${{ github.ref_name == 'master' }}
+          tags: |
+            ghcr.io/chitoku-k/chitoku.jp:latest
           build-args: |
             CI
       - name: Run eslint


### PR DESCRIPTION
This PR changes CI/CD to publish `latest` images on push to master branch. The `latest` tag is no longer stable.