### PR TITLE
Fix eslint rules for .storybook/**/*.mjs

### DIFF
--- a/.storybook/main.mjs
+++ b/.storybook/main.mjs
@@ -1,5 +1,3 @@
-'use strict'
-
 import webpack from 'webpack'
 import TsconfigPathsPlugin from 'tsconfig-paths-webpack-plugin'
 
@@ -40,7 +38,7 @@ const config = {
 
     config.module.rules.push({
       test: /\.m?js$/u,
-      include: /node_modules\/(gatsby|gatsby-script)\//u,
+      include: /node_modules\/(?:gatsby|gatsby-script)\//u,
       use: [
         {
           loader: 'babel-loader',
@@ -123,7 +121,7 @@ const config = {
     ]
 
     config.plugins.push(new webpack.ProvidePlugin({
-        process: 'process/browser',
+      process: 'process/browser',
     }))
 
     return config

--- a/.storybook/preview.mjs
+++ b/.storybook/preview.mjs
@@ -1,5 +1,3 @@
-'use strict'
-
 import { action } from 'storybook/actions'
 import '../src/styles/styles.scss'
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -13,7 +13,6 @@ export default [
   {
     ignores: [
       '.cache',
-      '.storybook',
       '.yarn',
       'public',
       'static',
@@ -99,6 +98,16 @@ export default [
           named: 'never',
         },
       ],
+    },
+  },
+  {
+    files: [
+      '.storybook/**/*.mjs',
+    ],
+    rules: {
+      'no-empty-function': 'off',
+      'no-shadow': 'off',
+      'no-underscore-dangle': 'off',
     },
   },
   {


### PR DESCRIPTION
Removes `.storybook` from `ignores` of eslint and fixes some issues currently found.