### PR TITLE
Use recommended rules from eslint, eslint-plugin-react, typescript-eslint, and @stylistic/eslint-plugin

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -3,6 +3,7 @@ import eslintPluginReact from 'eslint-plugin-react'
 import eslintPluginReactHooks from 'eslint-plugin-react-hooks'
 import eslintPluginStorybook from 'eslint-plugin-storybook'
 import globals from 'globals'
+import stylistic from '@stylistic/eslint-plugin'
 import typescriptEslint from 'typescript-eslint'
 
 /** @type {import('eslint').Linter.Config[]} */
@@ -10,6 +11,7 @@ export default [
   eslintJs.configs.recommended,
   eslintPluginReact.configs.flat.recommended,
   ...eslintPluginStorybook.configs['flat/recommended'],
+  stylistic.configs.recommended,
   {
     ignores: [
       '.cache',
@@ -34,6 +36,16 @@ export default [
   {
     rules: {
       'no-warning-comments': 'warn',
+      '@stylistic/array-bracket-spacing': [ 'error', 'always' ],
+      '@stylistic/arrow-parens': [ 'error', 'as-needed' ],
+      '@stylistic/jsx-one-expression-per-line': 'off',
+      '@stylistic/jsx-wrap-multilines': [
+        'error',
+        {
+          prop: 'ignore',
+        },
+      ],
+      '@stylistic/multiline-ternary': 'off',
     },
   },
   {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -7,8 +7,8 @@ import typescriptEslint from 'typescript-eslint'
 
 /** @type {import('eslint').Linter.Config[]} */
 export default [
-  eslintJs.configs.all,
-  eslintPluginReact.configs.flat.all,
+  eslintJs.configs.recommended,
+  eslintPluginReact.configs.flat.recommended,
   ...eslintPluginStorybook.configs['flat/recommended'],
   {
     ignores: [
@@ -33,81 +33,7 @@ export default [
   },
   {
     rules: {
-      'array-bracket-newline': 'off',
-      'array-bracket-spacing': [ 'error', 'always' ],
-      'array-element-newline': 'off',
-      'arrow-parens': [ 'error', 'as-needed' ],
-      'camelcase': 'off',
-      'comma-dangle': 'off',
-      'consistent-return': 'off',
-      'dot-location': [ 'error', 'property' ],
-      'function-call-argument-newline': 'off',
-      'id-length': 'off',
-      'indent': [ 'error', 2 ],
-      'init-declarations': 'off',
-      'max-len': 'off',
-      'max-lines': 'off',
-      'max-lines-per-function': 'off',
-      'max-statements': 'off',
-      'multiline-comment-style': 'off',
-      'multiline-ternary': 'off',
-      'no-continue': 'off',
-      'no-confusing-arrow': 'off',
-      'no-extra-parens': 'off',
-      'no-magic-numbers': 'off',
-      'no-mixed-operators': 'off',
-      'no-negated-condition': 'off',
-      'no-nested-ternary': 'off',
-      'no-process-env': 'off',
-      'no-ternary': 'off',
-      'no-undefined': 'off',
       'no-warning-comments': 'warn',
-      'object-curly-spacing': [ 'error', 'always' ],
-      'object-property-newline': 'off',
-      'one-var': [
-        'error',
-        {
-          initialized: 'never',
-          uninitialized: 'always',
-        },
-      ],
-      'padded-blocks': [ 'error', 'never' ],
-      'prefer-arrow-callback': [
-        'error',
-        {
-          allowNamedFunctions: true,
-        },
-      ],
-      'prefer-destructuring': 'off',
-      'quote-props': [ 'error', 'consistent-as-needed' ],
-      'quotes': [ 'error', 'single' ],
-      'semi': [ 'error', 'never' ],
-      'sort-imports': [
-        'warn',
-        {
-          ignoreDeclarationSort: true,
-        },
-      ],
-      'sort-keys': 'off',
-      'sort-vars': 'off',
-      'space-before-function-paren': [
-        'error',
-        {
-          anonymous: 'always',
-          asyncArrow: 'always',
-          named: 'never',
-        },
-      ],
-    },
-  },
-  {
-    files: [
-      '.storybook/**/*.mjs',
-    ],
-    rules: {
-      'no-empty-function': 'off',
-      'no-shadow': 'off',
-      'no-underscore-dangle': 'off',
     },
   },
   {
@@ -123,37 +49,13 @@ export default [
       },
     },
     rules: {
-      ...Object.assign({}, ...typescriptEslint.configs.all.map(({ rules }) => rules)),
-      '@typescript-eslint/camelcase': 'off',
-      '@typescript-eslint/explicit-function-return-type': [
-        'warn',
-        {
-          allowExpressions: true,
-          allowTypedFunctionExpressions: true,
-        },
-      ],
-      '@typescript-eslint/naming-convention': 'off',
-      '@typescript-eslint/no-confusing-void-expression': 'off',
-      '@typescript-eslint/no-magic-numbers': 'off',
-      '@typescript-eslint/no-type-alias': [
-        'error',
-        {
-          allowAliases: 'always',
-          allowConditionalTypes: 'always',
-          allowGenerics: 'always',
-          allowLiterals: 'always',
-          allowMappedTypes: 'always',
-        },
-      ],
-      '@typescript-eslint/no-unnecessary-type-parameters': 'off',
-      '@typescript-eslint/no-unsafe-assignment': 'off',
+      ...Object.assign({}, ...typescriptEslint.configs.recommendedTypeChecked.map(({ rules }) => rules)),
       '@typescript-eslint/no-unused-vars': [
         'error',
         {
           ignoreRestSiblings: true,
         },
       ],
-      '@typescript-eslint/prefer-readonly-parameter-types': 'off',
       '@typescript-eslint/restrict-template-expressions': [
         'error',
         {
@@ -161,45 +63,10 @@ export default [
           allowNumber: true,
         },
       ],
-      '@typescript-eslint/strict-boolean-expressions': 'off',
-      '@typescript-eslint/typedef': 'off',
       '@typescript-eslint/unbound-method': 'off',
-      'no-duplicate-imports': 'off',
-      'one-var': 'off',
-      'react/forbid-component-props': 'off',
-      'react/function-component-definition': 'off',
-      'react/jsx-closing-bracket-location': [ 'error', 'after-props' ],
-      'react/jsx-filename-extension': [
-        'error',
-        {
-          extensions: [ '.tsx' ],
-        },
-      ],
-      'react/jsx-first-prop-new-line': 'off',
-      'react/jsx-indent': [ 'error', 2 ],
-      'react/jsx-indent-props': [ 'error', 2 ],
-      'react/jsx-max-depth': 'off',
-      'react/jsx-max-props-per-line': 'off',
-      'react/jsx-newline': 'off',
-      'react/jsx-no-literals': 'off',
-      'react/jsx-one-expression-per-line': 'off',
-      'react/jsx-props-no-spreading': 'off',
-      'react/jsx-sort-props': 'off',
-      'react/jsx-uses-react': 'off',
-      'react/no-adjacent-inline-elements': 'off',
-      'react/no-invalid-html-attribute': 'off',
-      'react/no-multi-comp': [
-        'error',
-        {
-          ignoreStateless: true,
-        },
-      ],
-      'react/no-unused-prop-types': 'off',
-      'react/prefer-read-only-props': 'off',
       'react/prop-types': 'off',
       'react/react-in-jsx-scope': 'off',
-      'react/require-default-props': 'off',
-      'react-hooks/exhaustive-deps': 'warn',
+      'react-hooks/exhaustive-deps': 'error',
       'react-hooks/rules-of-hooks': 'error',
     },
   },

--- a/gatsby-node.ts
+++ b/gatsby-node.ts
@@ -43,7 +43,7 @@ export const onCreateWebpackConfig: GatsbyNode['onCreateWebpackConfig'] = ({
 
   if (stage === 'build-javascript') {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-    const config: Configuration = getConfig()
+    const config = getConfig() as Configuration
     if (config.optimization) {
       config.optimization.minimizer = [
         // eslint-disable-next-line @typescript-eslint/no-unsafe-call

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@storybook/addon-links": "^9.1.7",
     "@storybook/addon-webpack5-compiler-babel": "^3.0.6",
     "@storybook/react-webpack5": "^9.1.7",
+    "@stylistic/eslint-plugin": "^5.4.0",
     "@svgr/webpack": "^8.1.0",
     "@types/dotenv-safe": "^9.1.0",
     "@types/gatsbyjs__reach-router": "^2.0.5",

--- a/plugins/historia-taxonomy-plugin/gatsby-node.ts
+++ b/plugins/historia-taxonomy-plugin/gatsby-node.ts
@@ -94,7 +94,6 @@ export const createPages: GatsbyNode['createPages'] = async ({
 const isPluginObject = (plugin: PluginRef): plugin is IPluginRefObject => typeof plugin === 'object'
 
 export const createResolvers: GatsbyNode['createResolvers'] = ({
-  // eslint-disable-next-line @typescript-eslint/no-shadow
   createResolvers,
 }: CreateResolversArgs): void => {
   const plugin = config.plugins?.filter(isPluginObject).find(p => p.resolve === 'gatsby-transformer-remark')

--- a/src/components/About/index.tsx
+++ b/src/components/About/index.tsx
@@ -30,9 +30,12 @@ const About: FunctionComponent<AboutProps> = ({
             <img className={styles.icon} src={about.icon.src} />
             <br />
             <small>
-              <FormattedMessage {...messages.icon} values={{
-                name: <Link to={about.icon.url}>{about.icon.name}</Link>,
-              }} />
+              <FormattedMessage
+                {...messages.icon}
+                values={{
+                  name: <Link to={about.icon.url}>{about.icon.name}</Link>,
+                }}
+              />
             </small>
           </div>
         </Col>

--- a/src/components/About/index.tsx
+++ b/src/components/About/index.tsx
@@ -89,7 +89,6 @@ const About: FunctionComponent<AboutProps> = ({
               <tr>
                 <th>{formatMessage(messages.introduction)}</th>
                 <td>
-                  {/* eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion */}
                   <ArticleBody ast={(introduction?.markdown?.htmlAst ?? null) as unknown as Root} />
                 </td>
               </tr>

--- a/src/components/Article/index.tsx
+++ b/src/components/Article/index.tsx
@@ -86,7 +86,8 @@ const Article: FunctionComponent<ArticleProps> = ({
           <PaginationContainer>
             <SimplePagination
               prev={prev ? { title: prev.attributes.title, to: prev.path } : null}
-              next={next ? { title: next.attributes.title, to: next.path } : null} />
+              next={next ? { title: next.attributes.title, to: next.path } : null}
+            />
           </PaginationContainer>
         </ArticleContainer>
       ) : null}

--- a/src/components/Article/index.tsx
+++ b/src/components/Article/index.tsx
@@ -72,7 +72,6 @@ const Article: FunctionComponent<ArticleProps> = ({
           </Navbar>
         ) : null}
         <ArticleContext.Provider value={article}>
-          {/* eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion */}
           <ArticleBody ast={(excerptAst ?? htmlAst ?? null) as Root} />
         </ArticleContext.Provider>
         {excerpted && excerptAst ? (

--- a/src/components/ArticleAttribute/index.tsx
+++ b/src/components/ArticleAttribute/index.tsx
@@ -39,13 +39,16 @@ const ArticleAttribute: FunctionComponent<ArticleAttributeProps> = ({
         </span>
       ) : null}
       {typeof created === 'string' ? (
-        <span className={styles.item} title={formatDate(new Date(created), {
-          year: 'numeric',
-          month: 'narrow',
-          day: 'numeric',
-          hour: 'numeric',
-          minute: 'numeric',
-        })}>
+        <span
+          className={styles.item}
+          title={formatDate(new Date(created), {
+            year: 'numeric',
+            month: 'narrow',
+            day: 'numeric',
+            hour: 'numeric',
+            minute: 'numeric',
+          })}
+        >
           <FontAwesomeIcon className={styles.icon} icon={faCalendar} />
           {formatDate(new Date(created), {
             year: 'numeric',

--- a/src/components/ArticleBody/index.tsx
+++ b/src/components/ArticleBody/index.tsx
@@ -11,7 +11,6 @@ import * as styles from './styles.module.scss'
 const components: Record<string, ComponentType<unknown>> = {}
 
 export const register = function register<T>(key: string, component: ComponentType<T>): void {
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
   components[key] = component as ComponentType<unknown>
 }
 
@@ -21,9 +20,7 @@ const ArticleBody: FunctionComponent<ArticleBodyProps> = ({
   const processor = useMemo(
     () => unified()
       .use(rehypeReact, {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
         ...jsxRuntime as Production,
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
         components: components as Components,
       }),
     [],

--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -26,15 +26,21 @@ const Footer: FunctionComponent = () => {
   return (
     <footer className={styles.footer}>
       {commit && repositoryName && repositoryTreeUrl ? (
-        <FormattedMessage {...messages.copyright} values={{
-          link: <Link className={styles.link} to={`${repositoryTreeUrl}${commit.hash}`}>{repositoryName}</Link>,
-          license: <Link className={styles.link} to="/licenses.txt">{formatMessage(messages.license)}</Link>,
-        }} />
+        <FormattedMessage
+          {...messages.copyright}
+          values={{
+            link: <Link className={styles.link} to={`${repositoryTreeUrl}${commit.hash}`}>{repositoryName}</Link>,
+            license: <Link className={styles.link} to="/licenses.txt">{formatMessage(messages.license)}</Link>,
+          }}
+        />
       ) : (
-        <FormattedMessage {...messages.copyright} values={{
-          link: null,
-          license: <Link className={styles.link} to="/licenses.txt">{formatMessage(messages.license)}</Link>,
-        }} />
+        <FormattedMessage
+          {...messages.copyright}
+          values={{
+            link: null,
+            license: <Link className={styles.link} to="/licenses.txt">{formatMessage(messages.license)}</Link>,
+          }}
+        />
       )}
     </footer>
   )

--- a/src/components/Mail/index.tsx
+++ b/src/components/Mail/index.tsx
@@ -87,9 +87,12 @@ const Mail: FunctionComponent = () => {
       <Alert className={styles.notice} variant="info">
         {formatMessage(messages.contact_me_on_sns)}
         <br />
-        <FormattedMessage {...messages.contact_me_from_about} values={{
-          about: <Link to="/about">{formatMessage(messages.about)}</Link>,
-        }} />
+        <FormattedMessage
+          {...messages.contact_me_from_about}
+          values={{
+            about: <Link to="/about">{formatMessage(messages.about)}</Link>,
+          }}
+        />
       </Alert>
       <form onSubmit={onSubmit}>
         <Form.Group className={styles.group}>

--- a/src/components/Metadata/index.tsx
+++ b/src/components/Metadata/index.tsx
@@ -9,13 +9,13 @@ import messages from './messages'
 
 type ThumbnailURL = string
 type ThumbnailFile = string | null | undefined
-type ThumbnailPath<TURL extends string, TFile extends string | null | undefined> =
-  TFile extends string
+type ThumbnailPath<TURL extends string, TFile extends string | null | undefined>
+  = TFile extends string
     ? `${TURL}/thumbnails/${TFile}.png`
     : `${TURL}/thumbnails/default.png`
 
-const thumbnailPath =
-  (url: ThumbnailURL, file: ThumbnailFile): ThumbnailPath<ThumbnailURL, ThumbnailFile> => `${url}/thumbnails/${file ?? 'default'}.png` as ThumbnailPath<ThumbnailURL, ThumbnailFile>
+const thumbnailPath
+  = (url: ThumbnailURL, file: ThumbnailFile): ThumbnailPath<ThumbnailURL, ThumbnailFile> => `${url}/thumbnails/${file ?? 'default'}.png` as ThumbnailPath<ThumbnailURL, ThumbnailFile>
 
 const query = graphql`
   query MetadataItem {
@@ -91,26 +91,30 @@ const Metadata: FunctionComponent<MetadataProps> = ({ ...metadata }) => {
         <link rel="next" href={metadata.next} />
       ) : null}
       {metadata.breadcrumb ? (
-        <JsonLd<BreadcrumbList> item={{
-          '@context': 'https://schema.org',
-          '@type': 'BreadcrumbList',
-          'itemListElement': metadata.breadcrumb.map((item, position) => ({
-            '@type': 'ListItem',
-            position,
-            'item': {
-              '@type': 'Thing',
-              ...item,
-            },
-          })),
-        }} />
+        <JsonLd<BreadcrumbList>
+          item={{
+            '@context': 'https://schema.org',
+            '@type': 'BreadcrumbList',
+            'itemListElement': metadata.breadcrumb.map((item, position) => ({
+              '@type': 'ListItem',
+              position,
+              'item': {
+                '@type': 'Thing',
+                ...item,
+              },
+            })),
+          }}
+        />
       ) : null}
       {metadata.created ? (
-        <JsonLd<CreativeWork> item={{
-          '@context': 'https://schema.org',
-          '@type': 'Article',
-          'datePublished': metadata.created,
-          'thumbnailUrl': thumbnailPath(siteUrl, metadata.thumbnail),
-        }} />
+        <JsonLd<CreativeWork>
+          item={{
+            '@context': 'https://schema.org',
+            '@type': 'Article',
+            'datePublished': metadata.created,
+            'thumbnailUrl': thumbnailPath(siteUrl, metadata.thumbnail),
+          }}
+        />
       ) : null}
     </>
   )

--- a/src/components/NotFound/index.tsx
+++ b/src/components/NotFound/index.tsx
@@ -18,16 +18,19 @@ const Contact: FunctionComponent<ContactProps> = ({
     accounts,
   },
 }) => (
-  <FormattedMessage {...message} values={{
-    service,
-    account: (
-      <span>
-        {accounts
-          .map(({ url, name }) => url ? <Link to={url} key={url}>{name}</Link> : name)
-          .reduce<ReactNode[]>((prev, curr) => prev.length ? [ prev, ', ', curr ] : [ curr ], [])}
-      </span>
-    ),
-  }} />
+  <FormattedMessage
+    {...message}
+    values={{
+      service,
+      account: (
+        <span>
+          {accounts
+            .map(({ url, name }) => url ? <Link to={url} key={url}>{name}</Link> : name)
+            .reduce<ReactNode[]>((prev, curr) => prev.length ? [ prev, ', ', curr ] : [ curr ], [])}
+        </span>
+      ),
+    }}
+  />
 )
 
 interface ContactProps {
@@ -49,23 +52,32 @@ const NotFound: FunctionComponent<NotFoundProps> = ({ contacts }) => {
       <p>
         {formatMessage(messages.description)}
         <br />
-        <FormattedMessage {...messages.requested} values={{
-          url: <code>{location.href}</code>,
-        }} />
+        <FormattedMessage
+          {...messages.requested}
+          values={{
+            url: <code>{location.href}</code>,
+          }}
+        />
       </p>
       <p>
         {formatMessage(messages.try)}
       </p>
       <ul className={styles.tryList}>
         <li>
-          <FormattedMessage {...messages.go_to_home} values={{
-            home: <a href="/">{formatMessage(messages.home)}</a>,
-          }} />
+          <FormattedMessage
+            {...messages.go_to_home}
+            values={{
+              home: <a href="/">{formatMessage(messages.home)}</a>,
+            }}
+          />
         </li>
         <li>
-          <FormattedMessage {...messages.complain_to_administrator} values={{
-            administrator: <a href="/mail">{formatMessage(messages.administrator)}</a>,
-          }} />
+          <FormattedMessage
+            {...messages.complain_to_administrator}
+            values={{
+              administrator: <a href="/mail">{formatMessage(messages.administrator)}</a>,
+            }}
+          />
         </li>
         <li>
           {formatMessage(messages.give_up)}

--- a/src/components/Pagination/index.tsx
+++ b/src/components/Pagination/index.tsx
@@ -27,14 +27,17 @@ export const PaginationItem: FunctionComponent<Omit<ComponentPropsWithoutRef<'li
   ...rest
 }) => {
   const item = (
-    <BootstrapPagination.Item className={clsx(
-      styles.paginationItem,
-      !visible && styles.hidden,
-      !direction && styles.numbers,
-      direction === 'prev' && styles.prev,
-      direction === 'next' && styles.next,
-      className,
-    )} {...rest} />
+    <BootstrapPagination.Item
+      className={clsx(
+        styles.paginationItem,
+        !visible && styles.hidden,
+        !direction && styles.numbers,
+        direction === 'prev' && styles.prev,
+        direction === 'next' && styles.next,
+        className,
+      )}
+      {...rest}
+    />
   )
   return href ? <LinkContainer to={href}>{item}</LinkContainer> : item
 }
@@ -54,7 +57,8 @@ const Pagination: FunctionComponent<PaginationProps> = ({
           key={i}
           visible
           active={i + 1 === page.current}
-          href={i + 1 === page.current ? undefined : getPagePath(page.base, i + 1)}>
+          href={i + 1 === page.current ? undefined : getPagePath(page.base, i + 1)}
+        >
           {i + 1}
         </PaginationItem>
       ))}

--- a/src/components/PspSdkFunction/index.tsx
+++ b/src/components/PspSdkFunction/index.tsx
@@ -42,7 +42,6 @@ const PspSdkFunction: FunctionComponent<PspSdkFunctionProps> = ({
   return (
     <div className={styles.entry}>
       <pre className={clsx(styles.prototype, 'language-c')}>
-        {/* eslint-disable-next-line react/no-danger */}
         <code className="language-c" dangerouslySetInnerHTML={{ __html: highlighted }} />
       </pre>
       <div className={styles.description}>

--- a/src/components/PspSdkMacro/index.tsx
+++ b/src/components/PspSdkMacro/index.tsx
@@ -38,7 +38,6 @@ const PspSdkMacro: FunctionComponent<PspSdkMacroProps> = ({
   return (
     <div className={styles.entry}>
       <pre className={clsx(styles.prototype, 'language-c')}>
-        {/* eslint-disable-next-line react/no-danger */}
         <code className="language-c" dangerouslySetInnerHTML={{ __html: highlighted }} />
       </pre>
       <div className={styles.description}>

--- a/src/components/Search/index.tsx
+++ b/src/components/Search/index.tsx
@@ -57,11 +57,16 @@ const Hits: FunctionComponent<HitsProps> = ({
   if (!results.nbHits) {
     return (
       <div className={styles.noHits}>
-        <FormattedMessage {...messages.not_found} values={{
-          text: <strong>{results.query}</strong>,
-        }} />
+        <FormattedMessage
+          {...messages.not_found}
+          values={{
+            text: <strong>{results.query}</strong>,
+          }}
+        />
         <br />
-        <FormattedMessage {...messages.not_found_hints} />
+        <FormattedMessage
+          {...messages.not_found_hints}
+        />
       </div>
     )
   }
@@ -120,12 +125,15 @@ const Search: FunctionComponent<SearchProps> = ({
 
   return (
     <ArticleContainer>
-      <ArticleHeader className={styles.resultHeader} title={
-        <>
-          {title}
-          <PoweredBy classNames={{ logo: styles.logo }} theme={theme} />
-        </>
-      } />
+      <ArticleHeader
+        className={styles.resultHeader}
+        title={
+          <>
+            {title}
+            <PoweredBy classNames={{ logo: styles.logo }} theme={theme} />
+          </>
+        }
+      />
       {searchClient && indexName ? (
         <InstantSearch indexName={indexName} searchClient={searchClient}>
           <Refine query={query} />

--- a/src/components/Sidebar/buttons.tsx
+++ b/src/components/Sidebar/buttons.tsx
@@ -16,7 +16,6 @@ interface ShareButtonProps {
 
 const hatena: IconDefinition = {
   prefix: 'fab',
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
   iconName: 'hatena' as IconName,
   icon: [
     14,

--- a/src/components/TwitterTweet/index.tsx
+++ b/src/components/TwitterTweet/index.tsx
@@ -70,7 +70,8 @@ const TwitterTweet: FunctionComponent<TwitterTweetProps> = ({
         tweetId={id}
         options={tweetOptions}
         renderError={renderError({ id })}
-        {...rest} />
+        {...rest}
+      />
     </div>
   )
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -445,20 +445,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/generator@npm:^7.14.0, @babel/generator@npm:^7.20.14, @babel/generator@npm:^7.26.0, @babel/generator@npm:^7.27.3":
-  version: 7.27.3
-  resolution: "@babel/generator@npm:7.27.3"
-  dependencies:
-    "@babel/parser": "npm:^7.27.3"
-    "@babel/types": "npm:^7.27.3"
-    "@jridgewell/gen-mapping": "npm:^0.3.5"
-    "@jridgewell/trace-mapping": "npm:^0.3.25"
-    jsesc: "npm:^3.0.2"
-  checksum: 10/3b8477ae0c305639f86aeb553115535b103626008945462d32171fa4ebd77f2a0345600dc5baee7ced98d54cc7da9c806808a04b555c75136f42e0e9d7794bdf
-  languageName: node
-  linkType: hard
-
-"@babel/generator@npm:^7.28.3":
+"@babel/generator@npm:^7.14.0, @babel/generator@npm:^7.20.14, @babel/generator@npm:^7.26.0, @babel/generator@npm:^7.28.3":
   version: 7.28.3
   resolution: "@babel/generator@npm:7.28.3"
   dependencies:
@@ -618,20 +605,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-module-transforms@npm:^7.23.3, @babel/helper-module-transforms@npm:^7.26.0, @babel/helper-module-transforms@npm:^7.27.1":
-  version: 7.27.3
-  resolution: "@babel/helper-module-transforms@npm:7.27.3"
-  dependencies:
-    "@babel/helper-module-imports": "npm:^7.27.1"
-    "@babel/helper-validator-identifier": "npm:^7.27.1"
-    "@babel/traverse": "npm:^7.27.3"
-  peerDependencies:
-    "@babel/core": ^7.0.0
-  checksum: 10/47abc90ceb181b4bdea9bf1717adf536d1b5e5acb6f6d8a7a4524080318b5ca8a99e6d58677268c596bad71077d1d98834d2c3815f2443e6d3f287962300f15d
-  languageName: node
-  linkType: hard
-
-"@babel/helper-module-transforms@npm:^7.28.3":
+"@babel/helper-module-transforms@npm:^7.23.3, @babel/helper-module-transforms@npm:^7.26.0, @babel/helper-module-transforms@npm:^7.27.1, @babel/helper-module-transforms@npm:^7.28.3":
   version: 7.28.3
   resolution: "@babel/helper-module-transforms@npm:7.28.3"
   dependencies:
@@ -737,17 +711,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helpers@npm:^7.26.0":
-  version: 7.27.4
-  resolution: "@babel/helpers@npm:7.27.4"
-  dependencies:
-    "@babel/template": "npm:^7.27.2"
-    "@babel/types": "npm:^7.27.3"
-  checksum: 10/a697280575d338afd69461a07edb6db5b8623ca66528a9d2522e7b01476f42561b9563ab688b3ebe9e6afd4d25c6e66cc29a4466c424ab0d6573180c2bfdec0f
-  languageName: node
-  linkType: hard
-
-"@babel/helpers@npm:^7.28.4":
+"@babel/helpers@npm:^7.26.0, @babel/helpers@npm:^7.28.4":
   version: 7.28.4
   resolution: "@babel/helpers@npm:7.28.4"
   dependencies:
@@ -769,29 +733,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/parser@npm:^7.1.0, @babel/parser@npm:^7.14.0, @babel/parser@npm:^7.16.8, @babel/parser@npm:^7.20.13, @babel/parser@npm:^7.20.7, @babel/parser@npm:^7.26.0, @babel/parser@npm:^7.27.2, @babel/parser@npm:^7.27.3, @babel/parser@npm:^7.27.4":
-  version: 7.27.4
-  resolution: "@babel/parser@npm:7.27.4"
-  dependencies:
-    "@babel/types": "npm:^7.27.3"
-  bin:
-    parser: ./bin/babel-parser.js
-  checksum: 10/5ff6db87fd17de99792bf9a54480feeb069fc90ffa64ce96524c7437222549c86dde10fc1c945d4e9a94f3f2fc6ee4b3e1cfaf372f844bd054791e30089e92cf
-  languageName: node
-  linkType: hard
-
-"@babel/parser@npm:^7.28.3":
-  version: 7.28.3
-  resolution: "@babel/parser@npm:7.28.3"
-  dependencies:
-    "@babel/types": "npm:^7.28.2"
-  bin:
-    parser: ./bin/babel-parser.js
-  checksum: 10/9fa08282e345b9d892a6757b2789a9a53a00f7b7b34d6254a4ee0bf32c5eb275919091ea96d6f136a948d5de9c8219235957d04a36ab7378a9d93a4cf0799155
-  languageName: node
-  linkType: hard
-
-"@babel/parser@npm:^7.28.4":
+"@babel/parser@npm:^7.1.0, @babel/parser@npm:^7.14.0, @babel/parser@npm:^7.16.8, @babel/parser@npm:^7.20.13, @babel/parser@npm:^7.20.7, @babel/parser@npm:^7.26.0, @babel/parser@npm:^7.27.2, @babel/parser@npm:^7.28.3, @babel/parser@npm:^7.28.4":
   version: 7.28.4
   resolution: "@babel/parser@npm:7.28.4"
   dependencies:
@@ -1978,16 +1920,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.0.0, @babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.11.2, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.20.13, @babel/runtime@npm:^7.21.0, @babel/runtime@npm:^7.24.7, @babel/runtime@npm:^7.26.0, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.6.3, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.8.7, @babel/runtime@npm:^7.9.2":
-  version: 7.26.0
-  resolution: "@babel/runtime@npm:7.26.0"
-  dependencies:
-    regenerator-runtime: "npm:^0.14.0"
-  checksum: 10/9f4ea1c1d566c497c052d505587554e782e021e6ccd302c2ad7ae8291c8e16e3f19d4a7726fb64469e057779ea2081c28b7dbefec6d813a22f08a35712c0f699
-  languageName: node
-  linkType: hard
-
-"@babel/runtime@npm:^7.27.6":
+"@babel/runtime@npm:^7.0.0, @babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.11.2, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.20.13, @babel/runtime@npm:^7.21.0, @babel/runtime@npm:^7.24.7, @babel/runtime@npm:^7.26.0, @babel/runtime@npm:^7.27.6, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.6.3, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.8.7, @babel/runtime@npm:^7.9.2":
   version: 7.27.6
   resolution: "@babel/runtime@npm:7.27.6"
   checksum: 10/cc957a12ba3781241b83d528eb69ddeb86ca5ac43179a825e83aa81263a6b3eb88c57bed8a937cdeacfc3192e07ec24c73acdfea4507d0c0428c8e23d6322bfe
@@ -2005,37 +1938,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/traverse@npm:^7.14.0, @babel/traverse@npm:^7.16.8, @babel/traverse@npm:^7.18.9, @babel/traverse@npm:^7.20.13, @babel/traverse@npm:^7.25.9, @babel/traverse@npm:^7.27.1, @babel/traverse@npm:^7.27.3, @babel/traverse@npm:^7.9.0":
-  version: 7.27.4
-  resolution: "@babel/traverse@npm:7.27.4"
-  dependencies:
-    "@babel/code-frame": "npm:^7.27.1"
-    "@babel/generator": "npm:^7.27.3"
-    "@babel/parser": "npm:^7.27.4"
-    "@babel/template": "npm:^7.27.2"
-    "@babel/types": "npm:^7.27.3"
-    debug: "npm:^4.3.1"
-    globals: "npm:^11.1.0"
-  checksum: 10/4debb80b9068a46e188e478272f3b6820e16d17e2651e82d0a0457176b0c3b2489994f0a0d6e8941ee90218b0a8a69fe52ba350c1aa66eb4c72570d6b2405f91
-  languageName: node
-  linkType: hard
-
-"@babel/traverse@npm:^7.28.3":
-  version: 7.28.3
-  resolution: "@babel/traverse@npm:7.28.3"
-  dependencies:
-    "@babel/code-frame": "npm:^7.27.1"
-    "@babel/generator": "npm:^7.28.3"
-    "@babel/helper-globals": "npm:^7.28.0"
-    "@babel/parser": "npm:^7.28.3"
-    "@babel/template": "npm:^7.27.2"
-    "@babel/types": "npm:^7.28.2"
-    debug: "npm:^4.3.1"
-  checksum: 10/fe521591b719db010a89d9a39874386d0d67b79ee7e947eee7a8ef944bd3277cd92f3b39723fc9790dc4fb77f26b818db95712e147c599b9c4d98921eb4bc70b
-  languageName: node
-  linkType: hard
-
-"@babel/traverse@npm:^7.28.4":
+"@babel/traverse@npm:^7.14.0, @babel/traverse@npm:^7.16.8, @babel/traverse@npm:^7.18.9, @babel/traverse@npm:^7.20.13, @babel/traverse@npm:^7.25.9, @babel/traverse@npm:^7.27.1, @babel/traverse@npm:^7.28.3, @babel/traverse@npm:^7.28.4, @babel/traverse@npm:^7.9.0":
   version: 7.28.4
   resolution: "@babel/traverse@npm:7.28.4"
   dependencies:
@@ -2050,27 +1953,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/types@npm:^7.0.0, @babel/types@npm:^7.16.8, @babel/types@npm:^7.18.6, @babel/types@npm:^7.18.9, @babel/types@npm:^7.20.7, @babel/types@npm:^7.21.3, @babel/types@npm:^7.22.15, @babel/types@npm:^7.22.19, @babel/types@npm:^7.24.7, @babel/types@npm:^7.26.0, @babel/types@npm:^7.27.1, @babel/types@npm:^7.27.3, @babel/types@npm:^7.4.4, @babel/types@npm:^7.9.0, @babel/types@npm:^7.9.5":
-  version: 7.27.3
-  resolution: "@babel/types@npm:7.27.3"
-  dependencies:
-    "@babel/helper-string-parser": "npm:^7.27.1"
-    "@babel/helper-validator-identifier": "npm:^7.27.1"
-  checksum: 10/a24e6accd85c4747b974b3d68a3210d0aa1180c1a77b287ffcb7401cd2edad7bdecadaeb40fe5191be3990c3a5252943f7de7c09da13ed269adbb054b97056ee
-  languageName: node
-  linkType: hard
-
-"@babel/types@npm:^7.28.2":
-  version: 7.28.2
-  resolution: "@babel/types@npm:7.28.2"
-  dependencies:
-    "@babel/helper-string-parser": "npm:^7.27.1"
-    "@babel/helper-validator-identifier": "npm:^7.27.1"
-  checksum: 10/a8de404a2e3109651f346d892dc020ce2c82046068f4ce24de7f487738dfbfa7bd716b35f1dcd6d6c32dde96208dc74a56b7f56a2c0bcb5af0ddc56cbee13533
-  languageName: node
-  linkType: hard
-
-"@babel/types@npm:^7.28.4":
+"@babel/types@npm:^7.0.0, @babel/types@npm:^7.16.8, @babel/types@npm:^7.18.6, @babel/types@npm:^7.18.9, @babel/types@npm:^7.20.7, @babel/types@npm:^7.21.3, @babel/types@npm:^7.22.15, @babel/types@npm:^7.22.19, @babel/types@npm:^7.24.7, @babel/types@npm:^7.26.0, @babel/types@npm:^7.27.1, @babel/types@npm:^7.28.2, @babel/types@npm:^7.28.4, @babel/types@npm:^7.4.4, @babel/types@npm:^7.9.0, @babel/types@npm:^7.9.5":
   version: 7.28.4
   resolution: "@babel/types@npm:7.28.4"
   dependencies:
@@ -2306,25 +2189,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint-community/eslint-utils@npm:^4.2.0, @eslint-community/eslint-utils@npm:^4.7.0":
-  version: 4.7.0
-  resolution: "@eslint-community/eslint-utils@npm:4.7.0"
+"@eslint-community/eslint-utils@npm:^4.2.0, @eslint-community/eslint-utils@npm:^4.7.0, @eslint-community/eslint-utils@npm:^4.8.0, @eslint-community/eslint-utils@npm:^4.9.0":
+  version: 4.9.0
+  resolution: "@eslint-community/eslint-utils@npm:4.9.0"
   dependencies:
     eslint-visitor-keys: "npm:^3.4.3"
   peerDependencies:
     eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
-  checksum: 10/43ed5d391526d9f5bbe452aef336389a473026fca92057cf97c576db11401ce9bcf8ef0bf72625bbaf6207ed8ba6bf0dcf4d7e809c24f08faa68a28533c491a7
-  languageName: node
-  linkType: hard
-
-"@eslint-community/eslint-utils@npm:^4.8.0":
-  version: 4.8.0
-  resolution: "@eslint-community/eslint-utils@npm:4.8.0"
-  dependencies:
-    eslint-visitor-keys: "npm:^3.4.3"
-  peerDependencies:
-    eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
-  checksum: 10/d5d51162513c05cc5f055482f97336e813706a12d45cfc6c372c1802da7d30e31204eeb8c0ab9de0abc0fe1a3477c14711c3e43f3d58cedb8ade5d953576fa91
+  checksum: 10/89b1eb3137e14c379865e60573f524fcc0ee5c4b0c7cd21090673e75e5a720f14b92f05ab2d02704c2314b67e67b6f96f3bb209ded6b890ced7b667aa4bf1fa2
   languageName: node
   linkType: hard
 
@@ -3002,18 +2874,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jridgewell/gen-mapping@npm:^0.3.0, @jridgewell/gen-mapping@npm:^0.3.5":
-  version: 0.3.5
-  resolution: "@jridgewell/gen-mapping@npm:0.3.5"
-  dependencies:
-    "@jridgewell/set-array": "npm:^1.2.1"
-    "@jridgewell/sourcemap-codec": "npm:^1.4.10"
-    "@jridgewell/trace-mapping": "npm:^0.3.24"
-  checksum: 10/81587b3c4dd8e6c60252122937cea0c637486311f4ed208b52b62aae2e7a87598f63ec330e6cd0984af494bfb16d3f0d60d3b21d7e5b4aedd2602ff3fe9d32e2
-  languageName: node
-  linkType: hard
-
-"@jridgewell/gen-mapping@npm:^0.3.12":
+"@jridgewell/gen-mapping@npm:^0.3.0, @jridgewell/gen-mapping@npm:^0.3.12, @jridgewell/gen-mapping@npm:^0.3.5":
   version: 0.3.12
   resolution: "@jridgewell/gen-mapping@npm:0.3.12"
   dependencies:
@@ -3040,7 +2901,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jridgewell/set-array@npm:^1.0.0, @jridgewell/set-array@npm:^1.2.1":
+"@jridgewell/set-array@npm:^1.0.0":
   version: 1.2.1
   resolution: "@jridgewell/set-array@npm:1.2.1"
   checksum: 10/832e513a85a588f8ed4f27d1279420d8547743cc37fcad5a5a76fc74bb895b013dfe614d0eed9cb860048e6546b798f8f2652020b4b2ba0561b05caa8c654b10
@@ -3057,31 +2918,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jridgewell/sourcemap-codec@npm:^1.4.10, @jridgewell/sourcemap-codec@npm:^1.4.14, @jridgewell/sourcemap-codec@npm:^1.4.15":
-  version: 1.4.15
-  resolution: "@jridgewell/sourcemap-codec@npm:1.4.15"
-  checksum: 10/89960ac087781b961ad918978975bcdf2051cd1741880469783c42de64239703eab9db5230d776d8e6a09d73bb5e4cb964e07d93ee6e2e7aea5a7d726e865c09
-  languageName: node
-  linkType: hard
-
-"@jridgewell/sourcemap-codec@npm:^1.5.0":
+"@jridgewell/sourcemap-codec@npm:^1.4.10, @jridgewell/sourcemap-codec@npm:^1.4.14, @jridgewell/sourcemap-codec@npm:^1.4.15, @jridgewell/sourcemap-codec@npm:^1.5.0":
   version: 1.5.4
   resolution: "@jridgewell/sourcemap-codec@npm:1.5.4"
   checksum: 10/f677787f52224c6c971a7a41b7a074243240a6917fa75eceb9f7a442866f374fb0522b505e0496ee10a650c5936727e76d11bf36a6d0ae9e6c3b726c9e284cc7
   languageName: node
   linkType: hard
 
-"@jridgewell/trace-mapping@npm:^0.3.18, @jridgewell/trace-mapping@npm:^0.3.24, @jridgewell/trace-mapping@npm:^0.3.25, @jridgewell/trace-mapping@npm:^0.3.9":
-  version: 0.3.25
-  resolution: "@jridgewell/trace-mapping@npm:0.3.25"
-  dependencies:
-    "@jridgewell/resolve-uri": "npm:^3.1.0"
-    "@jridgewell/sourcemap-codec": "npm:^1.4.14"
-  checksum: 10/dced32160a44b49d531b80a4a2159dceab6b3ddf0c8e95a0deae4b0e894b172defa63d5ac52a19c2068e1fe7d31ea4ba931fbeec103233ecb4208953967120fc
-  languageName: node
-  linkType: hard
-
-"@jridgewell/trace-mapping@npm:^0.3.28":
+"@jridgewell/trace-mapping@npm:^0.3.18, @jridgewell/trace-mapping@npm:^0.3.24, @jridgewell/trace-mapping@npm:^0.3.25, @jridgewell/trace-mapping@npm:^0.3.28, @jridgewell/trace-mapping@npm:^0.3.9":
   version: 0.3.29
   resolution: "@jridgewell/trace-mapping@npm:0.3.29"
   dependencies:
@@ -4069,6 +3913,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@stylistic/eslint-plugin@npm:^5.4.0":
+  version: 5.4.0
+  resolution: "@stylistic/eslint-plugin@npm:5.4.0"
+  dependencies:
+    "@eslint-community/eslint-utils": "npm:^4.9.0"
+    "@typescript-eslint/types": "npm:^8.44.0"
+    eslint-visitor-keys: "npm:^4.2.1"
+    espree: "npm:^10.4.0"
+    estraverse: "npm:^5.3.0"
+    picomatch: "npm:^4.0.3"
+  peerDependencies:
+    eslint: ">=9.0.0"
+  checksum: 10/95bd7573bc4da932b1fe6da24d5032d14447d8ceeac13b5eaae567885819b76d96064c28ab76e8d98c1270de9647c8ec70e37b187786dd2be70e72f16d0a4dc6
+  languageName: node
+  linkType: hard
+
 "@svgr/babel-plugin-add-jsx-attribute@npm:8.0.0":
   version: 8.0.0
   resolution: "@svgr/babel-plugin-add-jsx-attribute@npm:8.0.0"
@@ -4474,14 +4334,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/estree@npm:*, @types/estree@npm:^1.0.0, @types/estree@npm:^1.0.6":
-  version: 1.0.6
-  resolution: "@types/estree@npm:1.0.6"
-  checksum: 10/9d35d475095199c23e05b431bcdd1f6fec7380612aed068b14b2a08aa70494de8a9026765a5a91b1073f636fb0368f6d8973f518a31391d519e20c59388ed88d
-  languageName: node
-  linkType: hard
-
-"@types/estree@npm:^1.0.8":
+"@types/estree@npm:*, @types/estree@npm:^1.0.0, @types/estree@npm:^1.0.6, @types/estree@npm:^1.0.8":
   version: 1.0.8
   resolution: "@types/estree@npm:1.0.8"
   checksum: 10/25a4c16a6752538ffde2826c2cc0c6491d90e69cd6187bef4a006dd2c3c45469f049e643d7e516c515f21484dc3d48fd5c870be158a5beb72f5baf3dc43e4099
@@ -4641,16 +4494,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:*, @types/node@npm:>=10.0.0":
-  version: 22.15.28
-  resolution: "@types/node@npm:22.15.28"
-  dependencies:
-    undici-types: "npm:~6.21.0"
-  checksum: 10/82ee399642729755f09aa59284f4ecf155451a39d268fd1c1f464aed9e1107842753cecab2058ad5f322a5487e534c1d7abe50801106f8844e74f0d1463dddc3
-  languageName: node
-  linkType: hard
-
-"@types/node@npm:^24.5.2":
+"@types/node@npm:*, @types/node@npm:>=10.0.0, @types/node@npm:^24.5.2":
   version: 24.5.2
   resolution: "@types/node@npm:24.5.2"
   dependencies:
@@ -4903,17 +4747,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/project-service@npm:8.33.0":
-  version: 8.33.0
-  resolution: "@typescript-eslint/project-service@npm:8.33.0"
-  dependencies:
-    "@typescript-eslint/tsconfig-utils": "npm:^8.33.0"
-    "@typescript-eslint/types": "npm:^8.33.0"
-    debug: "npm:^4.3.4"
-  checksum: 10/5fdc829a67092c2b764598facaf515ec114af2fcfdaf68af321aa667e4c4962fa6c19120efbde7ca234488b2bd7299015fb6b221b22253fe4ea3eae0bb72e494
-  languageName: node
-  linkType: hard
-
 "@typescript-eslint/project-service@npm:8.44.0":
   version: 8.44.0
   resolution: "@typescript-eslint/project-service@npm:8.44.0"
@@ -4937,16 +4770,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/scope-manager@npm:8.33.0":
-  version: 8.33.0
-  resolution: "@typescript-eslint/scope-manager@npm:8.33.0"
-  dependencies:
-    "@typescript-eslint/types": "npm:8.33.0"
-    "@typescript-eslint/visitor-keys": "npm:8.33.0"
-  checksum: 10/f52075c9ab3bdc69435f3b36583d2d5eb7bc66cfc8462184c9dc6dba5d0825e4d1d0f2e473ffaab5469fcfc4dc770908c26c1623b882d283739eb8e1869ab759
-  languageName: node
-  linkType: hard
-
 "@typescript-eslint/scope-manager@npm:8.44.0":
   version: 8.44.0
   resolution: "@typescript-eslint/scope-manager@npm:8.44.0"
@@ -4954,15 +4777,6 @@ __metadata:
     "@typescript-eslint/types": "npm:8.44.0"
     "@typescript-eslint/visitor-keys": "npm:8.44.0"
   checksum: 10/5dae4a838637df522f0f71d2df238b5fd5045a374cd036e7485d39fc1b20dd1151185463c8fc35441b12c747b795c88b429a5e229fc9449ae7b15d6e7e1b6caf
-  languageName: node
-  linkType: hard
-
-"@typescript-eslint/tsconfig-utils@npm:8.33.0, @typescript-eslint/tsconfig-utils@npm:^8.33.0":
-  version: 8.33.0
-  resolution: "@typescript-eslint/tsconfig-utils@npm:8.33.0"
-  peerDependencies:
-    typescript: ">=4.8.4 <5.9.0"
-  checksum: 10/5bb139be996a16f65c012c083e4c0dc2ddafd1295940203e6c2a1ac9fa0718b1a91f74354f162d3d9614b013e062863414d4478c57ffbf78dfd7cb4f5701abde
   languageName: node
   linkType: hard
 
@@ -5015,13 +4829,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/types@npm:8.33.0, @typescript-eslint/types@npm:^8.33.0":
-  version: 8.33.0
-  resolution: "@typescript-eslint/types@npm:8.33.0"
-  checksum: 10/778e812e2c3543e79168fe1072559d8bfef314a96b90da81805f9359f3b5cdfd202153c161723ccb1a4f8edb2593625aa5003f6235039bf189b39c93ff2605c2
-  languageName: node
-  linkType: hard
-
 "@typescript-eslint/types@npm:8.44.0, @typescript-eslint/types@npm:^8.44.0":
   version: 8.44.0
   resolution: "@typescript-eslint/types@npm:8.44.0"
@@ -5044,26 +4851,6 @@ __metadata:
     typescript:
       optional: true
   checksum: 10/06c975eb5f44b43bd19fadc2e1023c50cf87038fe4c0dd989d4331c67b3ff509b17fa60a3251896668ab4d7322bdc56162a9926971218d2e1a1874d2bef9a52e
-  languageName: node
-  linkType: hard
-
-"@typescript-eslint/typescript-estree@npm:8.33.0":
-  version: 8.33.0
-  resolution: "@typescript-eslint/typescript-estree@npm:8.33.0"
-  dependencies:
-    "@typescript-eslint/project-service": "npm:8.33.0"
-    "@typescript-eslint/tsconfig-utils": "npm:8.33.0"
-    "@typescript-eslint/types": "npm:8.33.0"
-    "@typescript-eslint/visitor-keys": "npm:8.33.0"
-    debug: "npm:^4.3.4"
-    fast-glob: "npm:^3.3.2"
-    is-glob: "npm:^4.0.3"
-    minimatch: "npm:^9.0.4"
-    semver: "npm:^7.6.0"
-    ts-api-utils: "npm:^2.1.0"
-  peerDependencies:
-    typescript: ">=4.8.4 <5.9.0"
-  checksum: 10/7cad508e5cc70a1e0bc72ee0448b0cc55e195c93124a25a8330c58fc3fee4e2762cbc8039ad13d40cb0ef2953239af9dbb4d3653636f605ed3f9414995af080c
   languageName: node
   linkType: hard
 
@@ -5105,7 +4892,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/utils@npm:8.44.0":
+"@typescript-eslint/utils@npm:8.44.0, @typescript-eslint/utils@npm:^8.8.1":
   version: 8.44.0
   resolution: "@typescript-eslint/utils@npm:8.44.0"
   dependencies:
@@ -5120,21 +4907,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/utils@npm:^8.8.1":
-  version: 8.33.0
-  resolution: "@typescript-eslint/utils@npm:8.33.0"
-  dependencies:
-    "@eslint-community/eslint-utils": "npm:^4.7.0"
-    "@typescript-eslint/scope-manager": "npm:8.33.0"
-    "@typescript-eslint/types": "npm:8.33.0"
-    "@typescript-eslint/typescript-estree": "npm:8.33.0"
-  peerDependencies:
-    eslint: ^8.57.0 || ^9.0.0
-    typescript: ">=4.8.4 <5.9.0"
-  checksum: 10/096011772d1ba6236413b1a49b8ad4f8999c0dcad1192ab81a13a753a95bfaf18cb138db94302cb00c312d410c7f48bb35ac1521908a55967e1fbba641aebcc5
-  languageName: node
-  linkType: hard
-
 "@typescript-eslint/visitor-keys@npm:5.62.0":
   version: 5.62.0
   resolution: "@typescript-eslint/visitor-keys@npm:5.62.0"
@@ -5142,16 +4914,6 @@ __metadata:
     "@typescript-eslint/types": "npm:5.62.0"
     eslint-visitor-keys: "npm:^3.3.0"
   checksum: 10/dc613ab7569df9bbe0b2ca677635eb91839dfb2ca2c6fa47870a5da4f160db0b436f7ec0764362e756d4164e9445d49d5eb1ff0b87f4c058946ae9d8c92eb388
-  languageName: node
-  linkType: hard
-
-"@typescript-eslint/visitor-keys@npm:8.33.0":
-  version: 8.33.0
-  resolution: "@typescript-eslint/visitor-keys@npm:8.33.0"
-  dependencies:
-    "@typescript-eslint/types": "npm:8.33.0"
-    eslint-visitor-keys: "npm:^4.2.0"
-  checksum: 10/f7f030c296dd83feb144f74aa382a67e4bb521d250507ede839f762bb215036d99d191b2203ac7af9867e434e569e4071ee0737cbde41d0ec38c0197f0a8549d
   languageName: node
   linkType: hard
 
@@ -5483,16 +5245,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"acorn@npm:^8.14.0, acorn@npm:^8.5.0, acorn@npm:^8.8.2":
-  version: 8.14.0
-  resolution: "acorn@npm:8.14.0"
-  bin:
-    acorn: bin/acorn
-  checksum: 10/6df29c35556782ca9e632db461a7f97947772c6c1d5438a81f0c873a3da3a792487e83e404d1c6c25f70513e91aa18745f6eafb1fcc3a43ecd1920b21dd173d2
-  languageName: node
-  linkType: hard
-
-"acorn@npm:^8.15.0":
+"acorn@npm:^8.14.0, acorn@npm:^8.15.0, acorn@npm:^8.5.0, acorn@npm:^8.8.2":
   version: 8.15.0
   resolution: "acorn@npm:8.15.0"
   bin:
@@ -8745,17 +8498,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"enhanced-resolve@npm:^5.15.0, enhanced-resolve@npm:^5.17.1, enhanced-resolve@npm:^5.7.0":
-  version: 5.17.1
-  resolution: "enhanced-resolve@npm:5.17.1"
-  dependencies:
-    graceful-fs: "npm:^4.2.4"
-    tapable: "npm:^2.2.0"
-  checksum: 10/e8e03cb7a4bf3c0250a89afbd29e5ec20e90ba5fcd026066232a0754864d7d0a393fa6fc0e5379314a6529165a1834b36731147080714459d98924520410d8f5
-  languageName: node
-  linkType: hard
-
-"enhanced-resolve@npm:^5.17.3":
+"enhanced-resolve@npm:^5.15.0, enhanced-resolve@npm:^5.17.1, enhanced-resolve@npm:^5.17.3, enhanced-resolve@npm:^5.7.0":
   version: 5.18.3
   resolution: "enhanced-resolve@npm:5.18.3"
   dependencies:
@@ -8963,18 +8706,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"es-set-tostringtag@npm:^2.0.3":
-  version: 2.0.3
-  resolution: "es-set-tostringtag@npm:2.0.3"
-  dependencies:
-    get-intrinsic: "npm:^1.2.4"
-    has-tostringtag: "npm:^1.0.2"
-    hasown: "npm:^2.0.1"
-  checksum: 10/7227fa48a41c0ce83e0377b11130d324ac797390688135b8da5c28994c0165be8b252e15cd1de41e1325e5a5412511586960213e88f9ab4a5e7d028895db5129
-  languageName: node
-  linkType: hard
-
-"es-set-tostringtag@npm:^2.1.0":
+"es-set-tostringtag@npm:^2.0.3, es-set-tostringtag@npm:^2.1.0":
   version: 2.1.0
   resolution: "es-set-tostringtag@npm:2.1.0"
   dependencies:
@@ -9409,13 +9141,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-visitor-keys@npm:^4.2.0":
-  version: 4.2.0
-  resolution: "eslint-visitor-keys@npm:4.2.0"
-  checksum: 10/9651b3356b01760e586b4c631c5268c0e1a85236e3292bf754f0472f465bf9a856c0ddc261fceace155334118c0151778effafbab981413dbf9288349343fa25
-  languageName: node
-  linkType: hard
-
 "eslint-visitor-keys@npm:^4.2.1":
   version: 4.2.1
   resolution: "eslint-visitor-keys@npm:4.2.1"
@@ -9552,18 +9277,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"espree@npm:^10.0.1":
-  version: 10.3.0
-  resolution: "espree@npm:10.3.0"
-  dependencies:
-    acorn: "npm:^8.14.0"
-    acorn-jsx: "npm:^5.3.2"
-    eslint-visitor-keys: "npm:^4.2.0"
-  checksum: 10/3412d44d4204c9e29d6b5dd0277400cfa0cd68495dc09eae1b9ce79d0c8985c1c5cc09cb9ba32a1cd963f48a49b0c46bdb7736afe395a300aa6bb1c0d86837e8
-  languageName: node
-  linkType: hard
-
-"espree@npm:^10.4.0":
+"espree@npm:^10.0.1, espree@npm:^10.4.0":
   version: 10.4.0
   resolution: "espree@npm:10.4.0"
   dependencies:
@@ -11752,7 +11466,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hasown@npm:^2.0.0, hasown@npm:^2.0.1, hasown@npm:^2.0.2":
+"hasown@npm:^2.0.0, hasown@npm:^2.0.2":
   version: 2.0.2
   resolution: "hasown@npm:2.0.2"
   dependencies:
@@ -11975,6 +11689,7 @@ __metadata:
     "@storybook/addon-links": "npm:^9.1.7"
     "@storybook/addon-webpack5-compiler-babel": "npm:^3.0.6"
     "@storybook/react-webpack5": "npm:^9.1.7"
+    "@stylistic/eslint-plugin": "npm:^5.4.0"
     "@svgr/webpack": "npm:^8.1.0"
     "@types/dotenv-safe": "npm:^9.1.0"
     "@types/gatsbyjs__reach-router": "npm:^2.0.5"
@@ -12390,14 +12105,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ignore@npm:^7.0.0":
-  version: 7.0.4
-  resolution: "ignore@npm:7.0.4"
-  checksum: 10/01ee59df2ffd14b0844efc17f5ab3642c848e45efdb7cc757928da5e076cb74313748f77f5ffe362a6407c5e7cc71f10fad5e8eb9d91c1a17c4e7ef2c1f8e40e
-  languageName: node
-  linkType: hard
-
-"ignore@npm:^7.0.5":
+"ignore@npm:^7.0.0, ignore@npm:^7.0.5":
   version: 7.0.5
   resolution: "ignore@npm:7.0.5"
   checksum: 10/f134b96a4de0af419196f52c529d5c6120c4456ff8a6b5a14ceaaa399f883e15d58d2ce651c9b69b9388491d4669dda47285d307e827de9304a53a1824801bc6
@@ -14080,14 +13788,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"loupe@npm:^3.1.0":
-  version: 3.1.3
-  resolution: "loupe@npm:3.1.3"
-  checksum: 10/9e98c34daf0eba48ccc603595e51f2ae002110982d84879cf78c51de2c632f0c571dfe82ce4210af60c32203d06b443465c269bda925076fe6d9b612cc65c321
-  languageName: node
-  linkType: hard
-
-"loupe@npm:^3.1.4":
+"loupe@npm:^3.1.0, loupe@npm:^3.1.4":
   version: 3.1.4
   resolution: "loupe@npm:3.1.4"
   checksum: 10/06ab1893731f167f2ce71f464a8a68372dc4cb807ecae20f9b844660c93813a298ca76bcd747ba6568b057af725ea63f0034ba3140c8f1d1fbb482d797e593ef
@@ -14177,21 +13878,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"magic-string@npm:^0.30.17":
+"magic-string@npm:^0.30.17, magic-string@npm:^0.30.5":
   version: 0.30.17
   resolution: "magic-string@npm:0.30.17"
   dependencies:
     "@jridgewell/sourcemap-codec": "npm:^1.5.0"
   checksum: 10/2f71af2b0afd78c2e9012a29b066d2c8ba45a9cd0c8070f7fd72de982fb1c403b4e3afdb1dae00691d56885ede66b772ef6bedf765e02e3a7066208fe2fec4aa
-  languageName: node
-  linkType: hard
-
-"magic-string@npm:^0.30.5":
-  version: 0.30.5
-  resolution: "magic-string@npm:0.30.5"
-  dependencies:
-    "@jridgewell/sourcemap-codec": "npm:^1.4.15"
-  checksum: 10/c8a6b25f813215ca9db526f3a407d6dc0bf35429c2b8111d6f1c2cf6cf6afd5e2d9f9cd189416a0e3959e20ecd635f73639f9825c73de1074b29331fe36ace59
   languageName: node
   linkType: hard
 
@@ -15402,15 +15094,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^3.3.8":
-  version: 3.3.8
-  resolution: "nanoid@npm:3.3.8"
-  bin:
-    nanoid: bin/nanoid.cjs
-  checksum: 10/2d1766606cf0d6f47b6f0fdab91761bb81609b2e3d367027aff45e6ee7006f660fb7e7781f4a34799fe6734f1268eeed2e37a5fdee809ade0c2d4eb11b0f9c40
-  languageName: node
-  linkType: hard
-
 "napi-build-utils@npm:^1.0.1":
   version: 1.0.2
   resolution: "napi-build-utils@npm:1.0.2"
@@ -16425,6 +16108,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"picomatch@npm:^4.0.3":
+  version: 4.0.3
+  resolution: "picomatch@npm:4.0.3"
+  checksum: 10/57b99055f40b16798f2802916d9c17e9744e620a0db136554af01d19598b96e45e2f00014c91d1b8b13874b80caa8c295b3d589a3f72373ec4aaf54baa5962d5
+  languageName: node
+  linkType: hard
+
 "pidtree@npm:^0.6.0":
   version: 0.6.0
   resolution: "pidtree@npm:0.6.0"
@@ -16995,18 +16685,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:^8.0.0, postcss@npm:^8.2.15, postcss@npm:^8.2.9, postcss@npm:^8.3.11, postcss@npm:^8.4.19, postcss@npm:^8.4.24, postcss@npm:^8.4.33, postcss@npm:^8.4.35, postcss@npm:^8.5.3":
-  version: 8.5.3
-  resolution: "postcss@npm:8.5.3"
-  dependencies:
-    nanoid: "npm:^3.3.8"
-    picocolors: "npm:^1.1.1"
-    source-map-js: "npm:^1.2.1"
-  checksum: 10/6d7e21a772e8b05bf102636918654dac097bac013f0dc8346b72ac3604fc16829646f94ea862acccd8f82e910b00e2c11c1f0ea276543565d278c7ca35516a7c
-  languageName: node
-  linkType: hard
-
-"postcss@npm:^8.5.6":
+"postcss@npm:^8.0.0, postcss@npm:^8.2.15, postcss@npm:^8.2.9, postcss@npm:^8.3.11, postcss@npm:^8.4.19, postcss@npm:^8.4.24, postcss@npm:^8.4.33, postcss@npm:^8.4.35, postcss@npm:^8.5.3, postcss@npm:^8.5.6":
   version: 8.5.6
   resolution: "postcss@npm:8.5.6"
   dependencies:
@@ -17704,7 +17383,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"readable-stream@npm:^3.0.2":
+"readable-stream@npm:^3.0.2, readable-stream@npm:^3.1.1, readable-stream@npm:^3.4.0, readable-stream@npm:^3.6.0":
   version: 3.6.2
   resolution: "readable-stream@npm:3.6.2"
   dependencies:
@@ -17712,17 +17391,6 @@ __metadata:
     string_decoder: "npm:^1.1.1"
     util-deprecate: "npm:^1.0.1"
   checksum: 10/d9e3e53193adcdb79d8f10f2a1f6989bd4389f5936c6f8b870e77570853561c362bee69feca2bbb7b32368ce96a85504aa4cedf7cf80f36e6a9de30d64244048
-  languageName: node
-  linkType: hard
-
-"readable-stream@npm:^3.1.1, readable-stream@npm:^3.4.0, readable-stream@npm:^3.6.0":
-  version: 3.6.0
-  resolution: "readable-stream@npm:3.6.0"
-  dependencies:
-    inherits: "npm:^2.0.3"
-    string_decoder: "npm:^1.1.1"
-    util-deprecate: "npm:^1.0.1"
-  checksum: 10/b80b3e6a7fafb1c79de7db541de357f4a5ee73bd70c21672f5a7c840d27bb27bdb0151e7ba2fd82c4a888df22ce0c501b0d9f3e4dfe51688876701c437d59536
   languageName: node
   linkType: hard
 
@@ -17830,13 +17498,6 @@ __metadata:
   version: 0.13.11
   resolution: "regenerator-runtime@npm:0.13.11"
   checksum: 10/d493e9e118abef5b099c78170834f18540c4933cedf9bfabc32d3af94abfb59a7907bd7950259cbab0a929ebca7db77301e8024e5121e6482a82f78283dfd20c
-  languageName: node
-  linkType: hard
-
-"regenerator-runtime@npm:^0.14.0":
-  version: 0.14.0
-  resolution: "regenerator-runtime@npm:0.14.0"
-  checksum: 10/6c19495baefcf5fbb18a281b56a97f0197b5f219f42e571e80877f095320afac0bdb31dab8f8186858e6126950068c3f17a1226437881e3e70446ea66751897c
   languageName: node
   linkType: hard
 
@@ -20726,13 +20387,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"undici-types@npm:~6.21.0":
-  version: 6.21.0
-  resolution: "undici-types@npm:6.21.0"
-  checksum: 10/ec8f41aa4359d50f9b59fa61fe3efce3477cc681908c8f84354d8567bb3701fafdddf36ef6bff307024d3feb42c837cf6f670314ba37fc8145e219560e473d14
-  languageName: node
-  linkType: hard
-
 "undici-types@npm:~7.12.0":
   version: 7.12.0
   resolution: "undici-types@npm:7.12.0"
@@ -21362,14 +21016,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"webpack-sources@npm:^3.0.0, webpack-sources@npm:^3.2.3":
-  version: 3.2.3
-  resolution: "webpack-sources@npm:3.2.3"
-  checksum: 10/a661f41795d678b7526ae8a88cd1b3d8ce71a7d19b6503da8149b2e667fc7a12f9b899041c1665d39e38245ed3a59ab68de648ea31040c3829aa695a5a45211d
-  languageName: node
-  linkType: hard
-
-"webpack-sources@npm:^3.3.3":
+"webpack-sources@npm:^3.0.0, webpack-sources@npm:^3.2.3, webpack-sources@npm:^3.3.3":
   version: 3.3.3
   resolution: "webpack-sources@npm:3.3.3"
   checksum: 10/ec5d72607e8068467370abccbfff855c596c098baedbe9d198a557ccf198e8546a322836a6f74241492576adba06100286592993a62b63196832cdb53c8bae91
@@ -21868,16 +21515,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yaml@npm:^2.0.0":
-  version: 2.8.0
-  resolution: "yaml@npm:2.8.0"
-  bin:
-    yaml: bin.mjs
-  checksum: 10/7d4bd9c10d0e467601f496193f2ac254140f8e36f96f5ff7f852b9ce37974168eb7354f4c36dc8837dde527a2043d004b6aff48818ec24a69ab2dd3c6b6c381c
-  languageName: node
-  linkType: hard
-
-"yaml@npm:^2.8.1":
+"yaml@npm:^2.0.0, yaml@npm:^2.8.1":
   version: 2.8.1
   resolution: "yaml@npm:2.8.1"
   bin:

--- a/yarn.lock
+++ b/yarn.lock
@@ -21037,44 +21037,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"webpack@npm:5":
-  version: 5.99.9
-  resolution: "webpack@npm:5.99.9"
-  dependencies:
-    "@types/eslint-scope": "npm:^3.7.7"
-    "@types/estree": "npm:^1.0.6"
-    "@types/json-schema": "npm:^7.0.15"
-    "@webassemblyjs/ast": "npm:^1.14.1"
-    "@webassemblyjs/wasm-edit": "npm:^1.14.1"
-    "@webassemblyjs/wasm-parser": "npm:^1.14.1"
-    acorn: "npm:^8.14.0"
-    browserslist: "npm:^4.24.0"
-    chrome-trace-event: "npm:^1.0.2"
-    enhanced-resolve: "npm:^5.17.1"
-    es-module-lexer: "npm:^1.2.1"
-    eslint-scope: "npm:5.1.1"
-    events: "npm:^3.2.0"
-    glob-to-regexp: "npm:^0.4.1"
-    graceful-fs: "npm:^4.2.11"
-    json-parse-even-better-errors: "npm:^2.3.1"
-    loader-runner: "npm:^4.2.0"
-    mime-types: "npm:^2.1.27"
-    neo-async: "npm:^2.6.2"
-    schema-utils: "npm:^4.3.2"
-    tapable: "npm:^2.1.1"
-    terser-webpack-plugin: "npm:^5.3.11"
-    watchpack: "npm:^2.4.1"
-    webpack-sources: "npm:^3.2.3"
-  peerDependenciesMeta:
-    webpack-cli:
-      optional: true
-  bin:
-    webpack: bin/webpack.js
-  checksum: 10/cf4a217239bcaa892f93702639ac837a16510edb7a1326955fb042d499d297cbdb16f20a81f3be6ec041b22ab47c599c757e505fdee1dd89b7f7a1ce4337fbf3
-  languageName: node
-  linkType: hard
-
-"webpack@npm:^5.101.3":
+"webpack@npm:5, webpack@npm:^5.101.3":
   version: 5.101.3
   resolution: "webpack@npm:5.101.3"
   dependencies:


### PR DESCRIPTION
This PR stops using `all` rules from ESLint core and their plugins and instead uses recommended rules as well as installs `@stylistic/eslint-plugin` and fixes reported issues.